### PR TITLE
Don't specify default len/cap sizes to make

### DIFF
--- a/cmd/gosimple/README.md
+++ b/cmd/gosimple/README.md
@@ -61,6 +61,7 @@ constructs:
 | S1016 | Converting two struct types by manually copying each field                  | A type conversion: `T(v)`                                              |
 | S1017 | `if strings.HasPrefix` + string slicing                                     | Call `strings.TrimPrefix` unconditionally                              |
 | S1018 | A loop sliding elements in a slice to the beginning                         | `copy(s[:n], s[offset:])`                                              |
+| S1019 | `make(T, 0)` or `make(T, x, x)`                                             | `make(T)` or `make(T, x)`                                              |
 
 ## gofmt -r
 

--- a/simple/lint.go
+++ b/simple/lint.go
@@ -1385,6 +1385,7 @@ func LintMakeLenCap(f *lint.File) {
 			return true
 		}
 		if fn, ok := call.Fun.(*ast.Ident); !ok || fn.Name != "make" {
+			// FIXME check whether make is indeed the built-in function
 			return true
 		}
 		switch len(call.Args) {
@@ -1393,7 +1394,7 @@ func LintMakeLenCap(f *lint.File) {
 			if _, ok := f.Pkg.TypesInfo.TypeOf(call.Args[0]).Underlying().(*types.Slice); ok {
 				break
 			}
-			if length, ok := call.Args[1].(*ast.BasicLit); ok && length.Value == "0" {
+			if lint.IsZero(call.Args[1]) {
 				f.Errorf(call.Args[1], "when length is zero, length can be omitted")
 			}
 		case 3:

--- a/simple/testdata/make-lencap.go
+++ b/simple/testdata/make-lencap.go
@@ -1,0 +1,17 @@
+package pkg
+
+func fn() {
+	const c = 0
+	var x, y int
+	type s []int
+	_ = make([]int, 1)
+	_ = make([]int, c)       // constant of 0 maybe due to debugging, math or platform-specific code
+	_ = make([]int, 0)       // length is mandatory for slices, don't suggest removal
+	_ = make(s, 0)           // length is mandatory for slices, don't suggest removal
+	_ = make(chan int, 0)    // MATCH /when length is zero, length can be omitted/
+	_ = make(map[int]int, 0) // MATCH /when length is zero, length can be omitted/
+	_ = make([]int, 1, 1)    // MATCH /when length equals capacity, capacity can be omitted/
+	_ = make([]int, x, x)    // MATCH /when length equals capacity, capacity can be omitted/
+	_ = make([]int, 1, 2)
+	_ = make([]int, x, y)
+}

--- a/simple/testdata/make-lencap.go
+++ b/simple/testdata/make-lencap.go
@@ -5,9 +5,9 @@ func fn() {
 	var x, y int
 	type s []int
 	_ = make([]int, 1)
-	_ = make([]int, c)       // constant of 0 maybe due to debugging, math or platform-specific code
 	_ = make([]int, 0)       // length is mandatory for slices, don't suggest removal
 	_ = make(s, 0)           // length is mandatory for slices, don't suggest removal
+	_ = make(chan int, c)    // constant of 0 maybe due to debugging, math or platform-specific code
 	_ = make(chan int, 0)    // MATCH /when length is zero, length can be omitted/
 	_ = make(map[int]int, 0) // MATCH /when length is zero, length can be omitted/
 	_ = make([]int, 1, 1)    // MATCH /when length equals capacity, capacity can be omitted/


### PR DESCRIPTION
See also original discussion: https://github.com/dominikh/go-simple/pull/29

See testdata for the main tests, but essentially, for any type T:

- `make(T, 0)` can be simplified to `make(T)` for non slice types
- `make(T, 1, 1)` can be simplified to `make(T, 1)`

Notes:
- I'm ignoring the type, as whether the type is a slice, chan or map, the same rules can be applied
- I'm not convinced on the README wording
- `constantInt` is a function copied from `staticcheck`, if this issue is accepted, perhaps it might be better to move this function to `lintuils`?
- I can remove the redundant selector tests, I was just ensuring it was catching the sel.sel.ident case
- Is there a better way to compare idents or selectors? I feel I maybe doing more work than required.
- I haven't ran this through my smaller corpus, I will be doing over the next 48 hours (slowly updating it now), so I haven't checked for false positives, panics etc