### PR TITLE
sync.Pool accepts a argument of size word, not only pointers

### DIFF
--- a/staticcheck/lint.go
+++ b/staticcheck/lint.go
@@ -1122,10 +1122,10 @@ func selectorX(sel *ast.SelectorExpr) ast.Node {
 	}
 }
 
-var checkDubiousSyncPoolPointersRules = map[string]CallRule{
+var checkDubiousSyncPoolPointersRules = map[string]CallRule{ // TODO(bradleyfalzon): Rename, as it no longer checks for pointers
 	"(*sync.Pool).Put": CallRule{
 		Arguments: []ArgumentRule{
-			Pointer{
+			OneWord{
 				argumentRule: argumentRule{
 					idx:     0,
 					Message: "non-pointer type put into sync.Pool",

--- a/staticcheck/rules.go
+++ b/staticcheck/rules.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"go/constant"
 	"go/types"
+	"log"
 	"net"
 	"net/url"
 	"regexp"
@@ -184,6 +185,24 @@ func (bc BufferedChannel) Validate(v ssa.Value, fn *ssa.Function, c *Checker) er
 		return errors.New("the channel should be buffered")
 	}
 	return nil
+}
+
+type OneWord struct {
+	argumentRule
+}
+
+func (w OneWord) Validate(v ssa.Value, fn *ssa.Function, c *Checker) error {
+	sizes := &types.StdSizes{WordSize: 8, MaxAlign: 8}
+
+	log.Printf("size of: %v", sizes.Sizeof(v.Type()))
+
+	if sizes.Sizeof(v.Type()) <= sizes.WordSize {
+		return nil
+	}
+	if w.Message != "" {
+		return errors.New(w.Message)
+	}
+	return errors.New("argument is expected to be one word or less")
 }
 
 type Pointer struct {


### PR DESCRIPTION
See also original discussion: https://github.com/dominikh/go-staticcheck/pull/72

This is an initial pass WIP, please provide feedback, but do not consider this completed. Thanks

@dominikh has pointed out: 

```
It (sync.Pool.Put) does not necessary needs to be a pointer. It just needs to be one
word (as least that's current implementation restriction). So pooling maps or structs 
containing 1 pointer is OK.
```

See: https://go-review.googlesource.com/#/c/24371/

Currently, the check looks for pointers to `sync.Pool.Put`. The above comment and CL suggests, to me, any argument with a size of word size (or less?) is valid.

If the above is true, the current WIP works by checking the type word size based on a amd64 architecture, but Go, and staticcheck support multiple architectures. Go vet manages a list of these at: https://github.com/golang/go/blob/6a3c6c0de822d5fb426f21c20529c9222c1ebee0/src/cmd/vet/asmdecl.go#L64-L98

How should this be handled, I don't believe we can access this from the types package (or at least it wasn't obvious to me), should we maintain our own list?

Looking forward to your thoughts as it's very likely I may have misunderstood.

Thanks