### PR TITLE
simple: add rule for unnecessary string copies

### DIFF
--- a/cmd/gosimple/README.md
+++ b/cmd/gosimple/README.md
@@ -64,6 +64,7 @@ constructs:
 | S1025 | `fmt.Sprintf("%s", x)` where `x` is already a string                        | `x`                                                                    |
 |       | `fmt.Sprintf("%s", x)` where `x`'s underlying type is a string              | `string(x)`                                                            |
 |       | `fmt.Sprintf("%s", x)` where `x` has a String method                        | `x.String()`                                                           |
+| S1026 | Copies of strings, like `string([]byte(x))` or `"" + x`                     | `x`                                                                    |
 
 ## gofmt -r
 

--- a/simple/testdata/LintStringCopy.go
+++ b/simple/testdata/LintStringCopy.go
@@ -1,0 +1,32 @@
+package pkg
+
+func fn(s string) {
+	_ = string([]byte(s)) // MATCH "should use s instead of string([]byte(s))"
+	_ = "" + s // MATCH /should use s instead of "" \+ s/
+	_ = s + "" // MATCH /should use s instead of s \+ ""/
+
+	_ = s
+	_ = s + "foo"
+	_ = s == ""
+	_ = s != ""
+	_ = "" +
+		"really long lines follow" +
+		"that need pretty formatting"
+
+	_ = string([]rune(s))
+	{
+		string := func(v interface{}) string {
+			return "foo"
+		}
+		_ = string([]byte(s))
+	}
+	{
+		type byte rune
+		_ = string([]byte(s))
+	}
+	{
+		type T []byte
+		var x T
+		_ = string([]byte(x))
+	}
+}


### PR DESCRIPTION
fmt.Sprintf("%s", s) will be handled by a separate rule.

Fixes #66.