### PR TITLE
simple: add a new check for redundant returns

### DIFF
--- a/cmd/gosimple/README.md
+++ b/cmd/gosimple/README.md
@@ -65,6 +65,7 @@ constructs:
 |       | `fmt.Sprintf("%s", x)` where `x`'s underlying type is a string              | `string(x)`                                                            |
 |       | `fmt.Sprintf("%s", x)` where `x` has a String method                        | `x.String()`                                                           |
 | S1026 | Copies of strings, like `string([]byte(x))` or `"" + x`                     | `x`                                                                    |
+| S1027 | `return` as the final statement of a func body with no return values        | Functions that don't return anything don't need a return statement     |
 
 ## gofmt -r
 

--- a/simple/testdata/LintRedundantReturn.go
+++ b/simple/testdata/LintRedundantReturn.go
@@ -1,0 +1,40 @@
+package pkg
+
+func fn1() {
+	return // MATCH /redundant return/
+}
+
+func fn2(a int) {
+	return // MATCH /redundant return/
+}
+
+func fn3() int {
+	return 3
+}
+
+func fn4() (n int) {
+	return
+}
+
+func fn5(b bool) {
+	if b {
+		return
+	}
+}
+
+func fn6() {
+	return
+	println("foo")
+}
+
+func fn7() {
+	return
+	println("foo")
+	return // MATCH /redundant return/
+}
+
+func fn8() {
+	_ = func() {
+		return // MATCH /redundant return/
+	}
+}


### PR DESCRIPTION
Fixes #64.

I manually checked `gosimple -tests=false std`; it has a handful of warnings and they're all correct.