### PR TITLE
simple: flag unnecessary conversions when using *bytes.Buffer

### DIFF
--- a/cmd/gosimple/README.md
+++ b/cmd/gosimple/README.md
@@ -68,6 +68,7 @@ constructs:
 | S1027 | `return` as the final statement of a func body with no return values        | Functions that don't return anything don't need a final return statement |
 | S1028 | `errors.New(fmt.Sprintf(...))`                                              | `fmt.Errorf(...)`                                                        |
 | S1029 | `for _, r := range []rune(s)`                                               | `for _, r := range s`                                                    |
+| S1030 | `[]byte` or `strings` conversion on a *bytes.Buffer `String()` or `Bytes()` | Use `Bytes()` or `String()` methods instead                              |
 
 ## gofmt -r
 

--- a/simple/lint.go
+++ b/simple/lint.go
@@ -67,6 +67,7 @@ func (c *Checker) Funcs() map[string]lint.Func {
 		"S1027": c.LintRedundantReturn,
 		"S1028": c.LintErrorsNewSprintf,
 		"S1029": c.LintRangeStringRunes,
+		"S1030": c.LintBytesConversion,
 	}
 }
 
@@ -240,6 +241,51 @@ func (c *Checker) LintIfBoolCmp(j *lint.Job) {
 			r = "!" + r
 		}
 		j.Errorf(expr, "should omit comparison to bool constant, can be simplified to %s", r)
+		return true
+	}
+	for _, f := range c.filterGenerated(j.Program.Files) {
+		ast.Inspect(f, fn)
+	}
+}
+
+func (c *Checker) LintBytesConversion(j *lint.Job) {
+	fn := func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || len(call.Args) != 1 {
+			return true
+		}
+
+		var castName string
+		switch typ := call.Fun.(type) {
+		case *ast.Ident:
+			if typ.Name != "string" {
+				return true
+			}
+			castName = "string"
+		case *ast.ArrayType:
+			if e, ok := typ.Elt.(*ast.Ident); !ok || e.Name != "byte" {
+				return true
+			}
+			castName = "[]byte"
+		default:
+			return true
+		}
+
+		argCall, ok := call.Args[0].(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := argCall.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+
+		switch {
+		case castName == "string" && j.IsCallToAST(call.Args[0], "(*bytes.Buffer).Bytes"):
+			j.Errorf(call, "should use %v.String() instead of %v", j.Render(sel.X), j.Render(call))
+		case castName == "[]byte" && j.IsCallToAST(call.Args[0], "(*bytes.Buffer).String"):
+			j.Errorf(call, "should use %v.Bytes() instead of %v", j.Render(sel.X), j.Render(call))
+		}
 		return true
 	}
 	for _, f := range c.filterGenerated(j.Program.Files) {

--- a/simple/lint.go
+++ b/simple/lint.go
@@ -258,12 +258,16 @@ func (c *Checker) LintBytesConversion(j *lint.Job) {
 		var castName string
 		switch typ := call.Fun.(type) {
 		case *ast.Ident:
-			if typ.Name != "string" {
+			if j.Program.Info.ObjectOf(typ).Type() != types.Universe.Lookup("string").Type() {
 				return true
 			}
 			castName = "string"
 		case *ast.ArrayType:
-			if e, ok := typ.Elt.(*ast.Ident); !ok || e.Name != "byte" {
+			arrTyp, ok := typ.Elt.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			if j.Program.Info.ObjectOf(arrTyp).Type() != types.Universe.Lookup("byte").Type() {
 				return true
 			}
 			castName = "[]byte"

--- a/simple/testdata/LintBytesConversion.go
+++ b/simple/testdata/LintBytesConversion.go
@@ -1,0 +1,16 @@
+package pkg
+
+import (
+	"bytes"
+)
+
+func fn() {
+	buf := bytes.NewBufferString("str")
+	_ = string(buf.Bytes())  // MATCH "should use buf.String() instead of string(buf.Bytes())"
+	_ = []byte(buf.String()) // MATCH "should use buf.Bytes() instead of []byte(buf.String())"
+
+	m := map[string]*bytes.Buffer{"key": buf}
+	_ = string(m["key"].Bytes())  // MATCH "should use m["key"].String() instead of string(m["key"].Bytes())"
+	_ = []byte(m["key"].String()) // MATCH "should use m["key"].Bytes() instead of []byte(m["key"].String())"
+
+}

--- a/simple/testdata/LintBytesConversion.go
+++ b/simple/testdata/LintBytesConversion.go
@@ -13,4 +13,8 @@ func fn() {
 	_ = string(m["key"].Bytes())  // MATCH "should use m["key"].String() instead of string(m["key"].Bytes())"
 	_ = []byte(m["key"].String()) // MATCH "should use m["key"].Bytes() instead of []byte(m["key"].String())"
 
+	string := func(_ interface{}) interface{} {
+		return nil
+	}
+	_ = string(m["key"].Bytes())
 }


### PR DESCRIPTION
Resolves #129 but only works for the test case provided, doesn't work if the selector is map (or other types). For example, the following test will fail:

```go
m := map[string]*bytes.Buffer{"key": buf}
_ = string(m["key"].Bytes())  // MATCH "should use buf.String() instead of string(buf.Bytes())"
_ = []byte(m["key"].String()) // MATCH "should use buf.Bytes() instead of []byte(buf.String())"
```

I had a look to see if this could be simplified further using other linter helpers, but couldn't see anything obvious, let me know if this can be improved.

Other cases in the wild: https://github.com/golang/crypto/blob/a48ac81e47fd6f9ed1258f3b60ae9e75f93cb7ed/openpgp/armor/armor_test.go#L53

Edit: I'm not convinced on the README description and the naming of testdata file or func.