### PR TITLE
SA9004: time equality check

### DIFF
--- a/cmd/staticcheck/README.md
+++ b/cmd/staticcheck/README.md
@@ -117,6 +117,7 @@ The following things are currently checked by staticcheck:
 |SA9001|`defer`s in `for range` loops may not run when you expect them to|
 |SA9002|Using a non-octal `os.FileMode`  that looks like it was meant to be in octal.|
 |SA9003|Empty body in an if or else branch|
+|SA9004|Using == or != operators to compare time.Time is problematic; prefer Time.Equal|
 |||
 
 ### <a id="SA1005">SA1005 – Invalid first argument to exec.Command

--- a/cmd/staticcheck/docs/checks/SA9004
+++ b/cmd/staticcheck/docs/checks/SA9004
@@ -1,0 +1,1 @@
+Using == or != operators to compare time.Time is problematic; prefer Time.Equal

--- a/staticcheck/lint.go
+++ b/staticcheck/lint.go
@@ -282,6 +282,7 @@ func (c *Checker) Funcs() map[string]lint.Func {
 		"SA9001": c.CheckDubiousDeferInChannelRangeLoop,
 		"SA9002": c.CheckNonOctalFileMode,
 		"SA9003": c.CheckEmptyBranch,
+		"SA9004": c.CheckTimeEqualityComparison,
 	}
 }
 
@@ -1182,6 +1183,29 @@ func (c *Checker) CheckDiffSizeComparison(j *lint.Job) {
 				if r1.Length.Intersection(r2.Length).Empty() {
 					j.Errorf(binop, "comparing strings of different sizes for equality will always return false")
 				}
+			}
+		}
+	}
+}
+
+func (c *Checker) CheckTimeEqualityComparison(j *lint.Job) {
+	for _, ssafn := range j.Program.InitialFunctions {
+		for _, block := range ssafn.Blocks {
+			for _, ins := range block.Instrs {
+				binop, ok := ins.(*ssa.BinOp)
+				if !ok {
+					continue
+				}
+				if binop.Op != token.EQL && binop.Op != token.NEQ {
+					continue
+				}
+
+				if types.TypeString(binop.X.Type(), nil) != "time.Time" ||
+					types.TypeString(binop.Y.Type(), nil) != "time.Time" {
+					continue
+				}
+
+				j.Errorf(binop, "using == or != operators to compare time is problematic; prefer Time.Equal")
 			}
 		}
 	}

--- a/staticcheck/testdata/CheckTimeEqualityComparison.go
+++ b/staticcheck/testdata/CheckTimeEqualityComparison.go
@@ -7,21 +7,21 @@ import (
 func fn1() {
 	var t1, t2 time.Time
 
-	_ = t1 == t2
-	_ = t1 != t2
+	_ = t1 == t2 // MATCH /using == or != operators to compare time is problematic/
+	_ = t1 != t2 // MATCH /using == or != operators to compare time is problematic/
 }
 
 func fn2() {
 	var t1, t2 *time.Time
 
-	_ = *t1 == *t2
-	_ = *t1 != *t2
+	_ = *t1 == *t2 // MATCH /using == or != operators to compare time is problematic/
+	_ = *t1 != *t2 // MATCH /using == or != operators to compare time is problematic/
 }
 
 func fn3() {
 	var t1 time.Time
 	var t2 *time.Time
 
-	_ = t1 == *t2
-	_ = t1 != *t2
+	_ = t1 == *t2 // MATCH /using == or != operators to compare time is problematic/
+	_ = t1 != *t2 // MATCH /using == or != operators to compare time is problematic/
 }

--- a/staticcheck/testdata/CheckTimeEqualityComparison.go
+++ b/staticcheck/testdata/CheckTimeEqualityComparison.go
@@ -1,0 +1,27 @@
+package pkg
+
+import (
+	"time"
+)
+
+func fn1() {
+	var t1, t2 time.Time
+
+	_ = t1 == t2
+	_ = t1 != t2
+}
+
+func fn2() {
+	var t1, t2 *time.Time
+
+	_ = *t1 == *t2
+	_ = *t1 != *t2
+}
+
+func fn3() {
+	var t1 time.Time
+	var t2 *time.Time
+
+	_ = t1 == *t2
+	_ = t1 != *t2
+}


### PR DESCRIPTION
Adds static check for reporting potentially problematic `time.Time` (in)equality comparisons