### PR TITLE
Log error when TypeOf on composite literal returns nil

### DIFF
--- a/cmd/keyify/keyify.go
+++ b/cmd/keyify/keyify.go
@@ -128,7 +128,13 @@ func main() {
 		printComplit(complit, lit, lprog.Fset, lprog.Fset)
 		return
 	}
-	_, ok := pkg.TypeOf(complit.Type).Underlying().(*types.Struct)
+
+	typ := pkg.TypeOf(complit.Type)
+	if typ == nil {
+		log.Fatal("cannot keyify implied struct type")
+	}
+
+	_, ok := typ.Underlying().(*types.Struct)
 	if !ok {
 		log.Fatal("not a struct initialiser")
 		return


### PR DESCRIPTION
This avoids a panic, in favor of logging an error when TypeOf
returns nil due to the type being implied from the slice type
the composite literal is defined within.

Steps to reproduce:

```go
package main

import "fmt"

type Thing struct {
	Stuff string
}

func main() {
	things := []Thing{
		{
			"",
		},
	}

	fmt.Println(things)
}
```

Run keyify on the implied composite literal inside the []Thing.