### PR TITLE
lint/lintutil: use runtime.GOARCH to determine type sizes

### DIFF
--- a/lint/lintutil/util.go
+++ b/lint/lintutil/util.go
@@ -270,6 +270,7 @@ func Lint(cs []lint.Checker, pkgs []string, opt *Options) ([][]lint.Problem, err
 		ParserMode: parser.ParseComments,
 		ImportPkgs: map[string]bool{},
 		TypeChecker: types.Config{
+			Sizes: types.SizesFor(build.Default.Compiler, build.Default.GOARCH),
 			Error: func(err error) {
 				// Only print the first error found
 				if hadError {


### PR DESCRIPTION
This arose while porting @cznic's crt to linux_arm. See https://github.com/cznic/crt/pull/3

Please take a look.