### PR TITLE
fix paths honnef.co -> github.com

### DIFF
--- a/cmd/keyify/README.md
+++ b/cmd/keyify/README.md
@@ -5,7 +5,7 @@ ones (`T{A: 1, B: 2, C: 3}`)
 
 Keyify requires Go 1.6 or later.
 
-    go get honnef.co/go/tools/cmd/keyify
+    go get github.com/dominikh/go-tools/cmd/keyify
 
 ## Usage
 

--- a/cmd/keyify/keyify.go
+++ b/cmd/keyify/keyify.go
@@ -16,7 +16,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"honnef.co/go/tools/version"
+	"github.com/dominikh/go-tools/version"
 
 	"golang.org/x/tools/go/ast/astutil"
 	"golang.org/x/tools/go/buildutil"


### PR DESCRIPTION
fix paths honnef.co -> github.com

I'm behind a corporate firewall, so I needed to fix up the path. Thanks for
your work ;-)