### PR TITLE
Not warn if backquote is included in the regexp string

### DIFF
--- a/simple/lint.go
+++ b/simple/lint.go
@@ -441,6 +441,9 @@ func (c *Checker) LintRegexpRaw(j *lint.Job) {
 		if !strings.Contains(val, `\\`) {
 			return true
 		}
+		if strings.Contains(val, "`") {
+			return true
+		}
 
 		bs := false
 		for _, c := range val {


### PR DESCRIPTION
When the string contains some backquotes, we cannot use raw string literal.
So S1007 should not be appeared when the string contains backquotes.