### PR TITLE
staticcheck: new check to detect unreachable case clauses in type switches

### DIFF
--- a/cmd/staticcheck/docs/checks/SA9005
+++ b/cmd/staticcheck/docs/checks/SA9005
@@ -1,0 +1,67 @@
+Unreachable case clause in a type switch
+
+In a type switch like this
+
+```
+type T struct{}
+func (T) Read(b []byte) (int, error) { return 0, nil }
+
+var v interface{} = T{}
+
+switch v.(type) {
+case io.Reader:
+    // ...
+case T:
+    // ...
+}
+```
+
+the second case clause can never be reached because `T` implements
+`io.Reader` and the case clause that checks that comes first in the source.
+
+Another example:
+
+```
+switch v.(type) {
+case io.Reader:
+    // ...
+case io.ReadCloser:
+    // unreachable
+}
+```
+
+Even if `v`'s value has `Close()`, thus implementing `io.ReadCloser`,
+`io.Reader` will always match first. This is because the methods of
+`io.Reader` are a subset of those of `io.ReadCloser`.
+
+#### Structurally equivalent interfaces
+
+Given these declarations
+
+```
+type T error
+type V error
+
+func doSomething() error {
+    err, ok := doAnotherThing()
+    if ok {
+        return T(err)
+    }
+
+    return U(err)
+}
+```
+
+the following type switch will have an unreachable case clause
+
+```
+switch doSomething().(type) {
+case T:
+    // ...
+case V:
+    // ...
+}
+```
+
+`T` will always match before `V` because they are structurally equivalent and
+therefore `doSomething()`'s return value implements both.

--- a/staticcheck/lint.go
+++ b/staticcheck/lint.go
@@ -2804,6 +2804,7 @@ func (c *Checker) CheckUnreachableTypeCases(j *lint.Job) {
 		return types.Implements(V, tIface)
 	}
 
+	subsumesAny := func(Ts, Vs []types.Type) (types.Type, types.Type, bool) {
 		for _, T := range Ts {
 			for _, V := range Vs {
 				if subsumes(T, V) {
@@ -2856,7 +2857,7 @@ func (c *Checker) CheckUnreachableTypeCases(j *lint.Job) {
 		// Check if case clauses following cc have types that are subsumed by cc.
 		for i, cc := range ccs[:len(ccs)-1] {
 			for _, next := range ccs[i+1:] {
-				if T, V, yes := intersect(cc.types, next.types); yes {
+				if T, V, yes := subsumesAny(cc.types, next.types); yes {
 					j.Errorf(next.cc, "unreachable case clause: %s will always match before %s", T.String(), V.String())
 				}
 			}

--- a/staticcheck/lint.go
+++ b/staticcheck/lint.go
@@ -2830,10 +2830,7 @@ func (c *Checker) CheckUnreachableTypeCases(j *lint.Job) {
 		// All asserted types in the order of case clauses.
 		ccs := []ccAndTypes{}
 		for _, stmt := range tsStmt.Body.List {
-			cc, ok := stmt.(*ast.CaseClause)
-			if !ok {
-				continue
-			}
+			cc, _ := stmt.(*ast.CaseClause)
 
 			// Exclude the 'default' case.
 			if len(cc.List) == 0 {

--- a/staticcheck/lint.go
+++ b/staticcheck/lint.go
@@ -2804,11 +2804,10 @@ func (c *Checker) CheckUnreachableTypeCases(j *lint.Job) {
 		return types.Implements(V, tIface)
 	}
 
-	intersect := func(Ts, Vs []types.Type) (types.Type, types.Type, bool) {
-		for i, T := range Ts {
-			for j, V := range Vs {
+		for _, T := range Ts {
+			for _, V := range Vs {
 				if subsumes(T, V) {
-					return Ts[i], Vs[j], true
+					return T, V, true
 				}
 			}
 		}

--- a/staticcheck/lint.go
+++ b/staticcheck/lint.go
@@ -2793,7 +2793,7 @@ func (c *Checker) CheckMissingEnumTypesInDeclaration(j *lint.Job) {
 func (c *Checker) CheckUnreachableTypeCases(j *lint.Job) {
 	// Check if T subsumes V in a type switch:
 	// T and V are structurally identical interfaces;
-	// interface T is a superset of V;
+	// interface T is a subset of V;
 	// T is an interface implemented by concrete type V.
 	subsumes := func(T, V types.Type) bool {
 		tIface, ok := T.Underlying().(*types.Interface)

--- a/staticcheck/lint.go
+++ b/staticcheck/lint.go
@@ -2828,7 +2828,7 @@ func (c *Checker) CheckUnreachableTypeCases(j *lint.Job) {
 		}
 
 		// All asserted types in the order of case clauses.
-		ccs := []ccAndTypes{}
+		ccs := make([]ccAndTypes, 0, len(tsStmt.Body.List))
 		for _, stmt := range tsStmt.Body.List {
 			cc, _ := stmt.(*ast.CaseClause)
 
@@ -2837,16 +2837,12 @@ func (c *Checker) CheckUnreachableTypeCases(j *lint.Job) {
 				continue
 			}
 
-			Ts := []types.Type{}
-			for _, expr := range cc.List {
-				if T := TypeOf(j, expr); T != nil {
-					Ts = append(Ts, T)
-				}
+			Ts := make([]types.Type, len(cc.List))
+			for i, expr := range cc.List {
+				Ts[i] = TypeOf(j, expr)
 			}
 
-			if len(Ts) > 0 {
-				ccs = append(ccs, ccAndTypes{cc: cc, types: Ts})
-			}
+			ccs = append(ccs, ccAndTypes{cc: cc, types: Ts})
 		}
 
 		if len(ccs) <= 1 {

--- a/staticcheck/testdata/CheckUnreachableTypeCases.go
+++ b/staticcheck/testdata/CheckUnreachableTypeCases.go
@@ -1,0 +1,123 @@
+package pkg
+
+import "io"
+
+type T struct{}
+
+func (T) Read(b []byte) (int, error) { return 0, nil }
+func (T) something() string          { return "non-exported method" }
+
+type V error
+type U error
+
+func fn1() {
+	var (
+		v   interface{}
+		err error
+	)
+
+	switch v.(type) {
+	case io.Reader:
+		println("io.Reader")
+	case io.ReadCloser: // MATCH "unreachable case clause: io.Reader will always match before io.ReadCloser"
+		println("io.ReadCloser")
+	}
+
+	switch v.(type) {
+	case io.Reader:
+		println("io.Reader")
+	case T: // MATCH "unreachable case clause: io.Reader will always match before CheckUnreachableTypeCases.go.T"
+		println("T")
+	}
+
+	switch v.(type) {
+	case io.Reader:
+		println("io.Reader")
+	case io.ReadCloser: // MATCH "unreachable case clause: io.Reader will always match before io.ReadCloser"
+		println("io.ReadCloser")
+	case T: // MATCH "unreachable case clause: io.Reader will always match before CheckUnreachableTypeCases.go.T"
+		println("T")
+	}
+
+	switch v.(type) {
+	case io.Reader:
+		println("io.Reader")
+	case io.ReadCloser, T: // MATCH "unreachable case clause: io.Reader will always match before io.ReadCloser"
+		println("io.ReadCloser or T")
+	}
+
+	switch v.(type) {
+	case io.ReadCloser, io.Reader:
+		println("io.ReadCloser or io.Reader")
+	case T: // MATCH "unreachable case clause: io.Reader will always match before CheckUnreachableTypeCases.go.T"
+		println("T")
+	}
+
+	switch v.(type) {
+	default:
+		println("something else")
+	case io.Reader:
+		println("io.Reader")
+	case T: // MATCH "unreachable case clause: io.Reader will always match before CheckUnreachableTypeCases.go.T"
+		println("T")
+	}
+
+	switch err.(type) {
+	case V:
+		println("V")
+	case U: // MATCH "unreachable case clause: CheckUnreachableTypeCases.go.V will always match before CheckUnreachableTypeCases.go.U"
+		println("U")
+	}
+
+	switch err.(type) {
+	case U:
+		println("U")
+	case V: // MATCH "unreachable case clause: CheckUnreachableTypeCases.go.U will always match before CheckUnreachableTypeCases.go.V"
+		println("V")
+	}
+}
+
+func fn3() {
+	var (
+		v   interface{}
+		err error
+	)
+
+	switch v.(type) {
+	case T:
+		println("T")
+	case io.Reader:
+		println("io.Reader")
+	}
+
+	switch v.(type) {
+	case io.ReadCloser:
+		println("io.ReadCloser")
+	case T:
+		println("T")
+	}
+
+	switch v.(type) {
+	case io.ReadCloser:
+		println("io.ReadCloser")
+	case io.Reader:
+		println("io.Reader")
+	}
+
+	switch v.(type) {
+	case T:
+		println("T")
+	}
+
+	switch err.(type) {
+	case V, U:
+		println("V or U")
+	case io.Reader:
+		println("io.Reader")
+	}
+
+	switch v.(type) {
+	default:
+		println("something")
+	}
+}


### PR DESCRIPTION
Detect type switches like this one:

```
switch v.(type) {
case io.Reader:
    // ...
case io.ReadCloser:
    // unreachable
}
```

and similar.