### PR TITLE
staticcheck: new check for inefficient string comparisons with strings.ToLower/strings.ToUpper

### DIFF
--- a/cmd/staticcheck/docs/checks/SA6005
+++ b/cmd/staticcheck/docs/checks/SA6005
@@ -1,0 +1,20 @@
+Inefficient string comparison with strings.ToLower or strings.ToUpper
+
+Converting two strings to the same case and comparing them like so
+
+```
+if strings.ToLower(s1) == strings.ToLower(s2) {
+    ...
+}
+```
+
+or
+
+```
+if strings.ToUpper(s1) != strings.ToUpper(s2) {
+    ...
+}
+```
+
+may result in `len(s1) + len(s2) + len(s2)` iterations in the worst case
+whereas `strings.EqualFold` will do `len(s1)` at most.

--- a/staticcheck/testdata/CheckToLowerToUpperComparison.go
+++ b/staticcheck/testdata/CheckToLowerToUpperComparison.go
@@ -1,0 +1,43 @@
+package pkg
+
+import "strings"
+
+func fn() {
+	const (
+		s1 = "foo"
+		s2 = "bar"
+	)
+
+	if strings.ToLower(s1) == strings.ToLower(s2) { // MATCH "strings.ToLower(a) == strings.ToLower(b) is better written as strings.EqualFold(a, b)"
+		panic("")
+	}
+
+	if strings.ToUpper(s1) == strings.ToUpper(s2) { // MATCH "strings.ToUpper(a) == strings.ToUpper(b) is better written as strings.EqualFold(a, b)"
+		panic("")
+	}
+
+	if strings.ToLower(s1) != strings.ToLower(s2) { // MATCH "strings.ToLower(a) != strings.ToLower(b) is better written as !strings.EqualFold(a, b)"
+		panic("")
+	}
+
+	switch strings.ToLower(s1) == strings.ToLower(s2) { // MATCH "strings.ToLower(a) == strings.ToLower(b) is better written as strings.EqualFold(a, b)"
+	case true, false:
+		panic("")
+	}
+
+	if strings.ToLower(s1) == strings.ToLower(s2) || s1+s2 == s2+s1 { // MATCH "strings.ToLower(a) == strings.ToLower(b) is better written as strings.EqualFold(a, b)" {
+		panic("")
+	}
+
+	if strings.ToLower(s1) > strings.ToLower(s2) {
+		panic("")
+	}
+
+	if strings.ToLower(s1) < strings.ToLower(s2) {
+		panic("")
+	}
+
+	if strings.ToLower(s1) == strings.ToUpper(s2) {
+		panic("")
+	}
+}


### PR DESCRIPTION
A check to detect inefficient string comparisons described in https://blog.digitalocean.com/how-to-efficiently-compare-strings-in-go/. Extended to catch both `ToLower` and `ToUpper`.

Fixes #366.