### PR TITLE
stylish formatter: avoid panic if first Position to report is empty

### DIFF
--- a/lint/lintutil/format/format.go
+++ b/lint/lintutil/format/format.go
@@ -102,6 +102,10 @@ type Stylish struct {
 }
 
 func (o *Stylish) Format(p lint.Problem) {
+	if p.Position.Filename == "" {
+		p.Position.Filename = "-"
+	}
+
 	if p.Position.Filename != o.prevFile {
 		if o.prevFile != "" {
 			o.tw.Flush()


### PR DESCRIPTION
Pointer tw was not initialised before use, if the first call to Format
was with an empty Position, leading to panic. 

This change forces the Filename to be something ("-"), to avoid that.