### PR TITLE
Emit a warning if the same package is imported under different names.

### DIFF
--- a/stylecheck/analysis.go
+++ b/stylecheck/analysis.go
@@ -60,4 +60,8 @@ var Analyzers = lintutil.InitializeAnalyzers(Docs, map[string]*analysis.Analyzer
 		Run:      CheckInvisibleCharacters,
 		Requires: []*analysis.Analyzer{inspect.Analyzer},
 	},
+	"ST1019": {
+		Run:      CheckDuplicatedImports,
+		Requires: []*analysis.Analyzer{facts.Generated, config.Analyzer},
+	},
 })

--- a/stylecheck/doc.go
+++ b/stylecheck/doc.go
@@ -153,7 +153,7 @@ bug, we prefer the more idiomatic 'if x == 42'.`,
 	},
 
 	"ST1019": &lint.Documentation{
-		Title: `Don't import the same package under different names`,
+		Title: `Importing the same package multiple times`,
 		Since: "Unreleased",
 	},
 }

--- a/stylecheck/doc.go
+++ b/stylecheck/doc.go
@@ -151,4 +151,9 @@ bug, we prefer the more idiomatic 'if x == 42'.`,
 		Title: `Avoid zero-width and control characters in string literals`,
 		Since: "2019.2",
 	},
+
+	"ST1019": &lint.Documentation{
+		Title: `Don't import the same package under different names`,
+		Since: "Unreleased",
+	},
 }

--- a/stylecheck/lint.go
+++ b/stylecheck/lint.go
@@ -85,18 +85,14 @@ func CheckDuplicatedImports(pass *analysis.Pass) (interface{}, error) {
 		// Collect all imports by their import path
 		imports := make(map[string][]*ast.ImportSpec, len(f.Imports))
 		for _, imp := range f.Imports {
-			if current, ok := imports[imp.Path.Value]; !ok {
-				imports[imp.Path.Value] = []*ast.ImportSpec{imp}
-			} else {
-				imports[imp.Path.Value] = append(current, imp)
-			}
+			imports[imp.Path.Value] = append(imports[imp.Path.Value], imp)
 		}
 
 		for _, value := range imports {
 			// If there's more than one import per path, we flag that
 			if len(value) > 1 {
 				for _, imp := range value {
-					ReportNodefFG(pass, imp, "should not import the same package under different names")
+					ReportNodefFG(pass, imp, "should not import the same package multiple times")
 				}
 			}
 		}

--- a/stylecheck/lint_test.go
+++ b/stylecheck/lint_test.go
@@ -21,6 +21,7 @@ func TestAll(t *testing.T) {
 		"ST1016": {{Dir: "CheckReceiverNamesIdentical"}},
 		"ST1017": {{Dir: "CheckYodaConditions"}},
 		"ST1018": {{Dir: "CheckInvisibleCharacters"}},
+		"ST1019": {{Dir: "CheckDuplicatedImports"}},
 	}
 
 	testutil.Run(t, Analyzers, checks)

--- a/stylecheck/testdata/src/CheckDuplicatedImports/CheckDuplicatedImports.go
+++ b/stylecheck/testdata/src/CheckDuplicatedImports/CheckDuplicatedImports.go
@@ -7,9 +7,14 @@ import (
 	fmt2 "fmt" // want `should not import the same package under different names`
 
 	fine "net/http"
+
+	"os"     // want `should not import the same package under different names`
+	os1 "os" // want `should not import the same package under different names`
 )
 
 var _ = fmt.Println
 var _ = fmt1.Println
 var _ = fmt2.Println
 var _ = fine.ListenAndServe
+var _ = os.Getenv
+var _ = os1.Getenv

--- a/stylecheck/testdata/src/CheckDuplicatedImports/CheckDuplicatedImports.go
+++ b/stylecheck/testdata/src/CheckDuplicatedImports/CheckDuplicatedImports.go
@@ -1,0 +1,15 @@
+// Package pkg ...
+package pkg
+
+import (
+	"fmt"      // want `should not import the same package under different names`
+	fmt1 "fmt" // want `should not import the same package under different names`
+	fmt2 "fmt" // want `should not import the same package under different names`
+
+	fine "net/http"
+)
+
+var _ = fmt.Println
+var _ = fmt1.Println
+var _ = fmt2.Println
+var _ = fine.ListenAndServe

--- a/stylecheck/testdata/src/CheckDuplicatedImports/CheckDuplicatedImports.go
+++ b/stylecheck/testdata/src/CheckDuplicatedImports/CheckDuplicatedImports.go
@@ -2,14 +2,14 @@
 package pkg
 
 import (
-	"fmt"      // want `should not import the same package under different names`
-	fmt1 "fmt" // want `should not import the same package under different names`
-	fmt2 "fmt" // want `should not import the same package under different names`
+	"fmt"      // want `should not import the same package multiple times`
+	fmt1 "fmt" // want `should not import the same package multiple times`
+	fmt2 "fmt" // want `should not import the same package multiple times`
 
 	fine "net/http"
 
-	"os"     // want `should not import the same package under different names`
-	os1 "os" // want `should not import the same package under different names`
+	"os"     // want `should not import the same package multiple times`
+	os1 "os" // want `should not import the same package multiple times`
 )
 
 var _ = fmt.Println


### PR DESCRIPTION
Fix #467.

Sorry I didn't wait for you to confirm you need help. Feel free to bin this if there's an implementation around already.

As always: Feel free to point out whichever nits you have. I put this into `stylecheck` because the `.`-imports where there as well and it seemed a sensible place.

We could cut down in overhead if needed by not collecting all imports but by only marking subsequent ones (not the first).