### PR TITLE
facts: allow other fact types when running deprecated analysis

### DIFF
--- a/facts/deprecated.go
+++ b/facts/deprecated.go
@@ -134,10 +134,14 @@ func deprecated(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	for _, fact := range pass.AllObjectFacts() {
-		out.Objects[fact.Object] = fact.Fact.(*IsDeprecated)
+		if f, ok := fact.Fact.(*IsDeprecated); ok {
+			out.Objects[fact.Object] = f
+		}
 	}
 	for _, fact := range pass.AllPackageFacts() {
-		out.Packages[fact.Package] = fact.Fact.(*IsDeprecated)
+		if f, ok := fact.Fact.(*IsDeprecated); ok {
+			out.Packages[fact.Package] = f
+		}
 	}
 
 	return out, nil


### PR DESCRIPTION
When preparing the result of the deprecated analysis, allow fact
types other than IsDeprecated to be present. This will allow
this analysis to be run in an environment where other analyses
have populated facts.