### PR TITLE
all: fix typos in non-vendored code

### DIFF
--- a/lint/runner.go
+++ b/lint/runner.go
@@ -818,7 +818,7 @@ func (r *Runner) processPkg(pkg *Package, analyzers []*analysis.Analyzer) {
 	}()
 
 	// Ensure all packages have the generated map and config. This is
-	// required by interna of the runner. Analyses that themselves
+	// required by internal of the runner. Analyses that themselves
 	// make use of either have an explicit dependency so that other
 	// runners work correctly, too.
 	analyzers = append(analyzers[0:len(analyzers):len(analyzers)], injectedAnalyses...)

--- a/simple/lint.go
+++ b/simple/lint.go
@@ -408,7 +408,7 @@ func negate(expr ast.Expr) ast.Expr {
 	}
 }
 
-// LintRedundantNilCheckWithLen checks for the following reduntant nil-checks:
+// LintRedundantNilCheckWithLen checks for the following redundant nil-checks:
 //
 //   if x == nil || len(x) == 0 {}
 //   if x != nil && len(x) != 0 {}

--- a/simple/testdata/src/trim/trim.go
+++ b/simple/testdata/src/trim/trim.go
@@ -91,7 +91,7 @@ func fn() {
 	}
 
 	if strings.HasPrefix(id1, gen()) {
-		id1 = id1[len(gen()):] // dunamic id3
+		id1 = id1[len(gen()):] // dynamic id3
 	}
 
 	if strings.HasPrefix(id1, s1) {

--- a/staticcheck/testdata/src/CheckPrintf/CheckPrintf.go
+++ b/staticcheck/testdata/src/CheckPrintf/CheckPrintf.go
@@ -174,7 +174,7 @@ func fn() {
 	fmt.Printf(someString(), "hello") // OK
 
 	// d accepts pointers as long as they're not to structs.
-	// pointers to structs are dereferencd and walked.
+	// pointers to structs are dereferenced and walked.
 	fmt.Printf("%d", &s)
 
 	// staticcheck's own checks, based on bugs in go vet; see https://github.com/golang/go/issues/27672

--- a/stylecheck/names.go
+++ b/stylecheck/names.go
@@ -146,7 +146,7 @@ func CheckNames(pass *analysis.Pass) (interface{}, error) {
 				}
 			case *ast.InterfaceType:
 				// Do not check interface method names.
-				// They are often constrainted by the method names of concrete types.
+				// They are often constrained by the method names of concrete types.
 				for _, x := range v.Methods.List {
 					ft, ok := x.Type.(*ast.FuncType)
 					if !ok { // might be an embedded interface name

--- a/unused/unused_test.go
+++ b/unused/unused_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 // parseExpectations parses the content of a "// want ..." comment
-// and returns the expections, a mixture of diagnostics ("rx") and
+// and returns the expectations, a mixture of diagnostics ("rx") and
 // facts (name:"rx").
 func parseExpectations(text string) ([]string, error) {
 	var scanErr string


### PR DESCRIPTION
Not sure about the phrase in `lint/runner.go` though.