### PR TITLE
Exclude the files broken on purpose from Gofmt check in circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ gofmt: &gofmt
         at: "/go/"
     - run:
         name: "gofmt"
-        command: "[ -z \"$(gofmt -l .)\" ] || exit $?"
+        command: "[ -z \"$(gofmt -l $(find . -iname '*.go' -not -path '*broken*'))\" ] || exit $?"
 
 test: &test
   steps:


### PR DESCRIPTION
In CircleCI we currently check for formatting using `gofmt -l .` but that makes the job fail because of test files that are malformed on purpose. Example: https://circleci.com/gh/dominikh/go-tools/1059

This PR excludes those files to avoid those issues and fail only when the issue is real.