### PR TITLE
Add stats about ignored issues in stylish mode

### DIFF
--- a/lint/lintutil/format/format.go
+++ b/lint/lintutil/format/format.go
@@ -39,7 +39,7 @@ func relativePositionString(pos token.Position) string {
 }
 
 type Statter interface {
-	Stats(total, errors, warnings int)
+	Stats(total, errors, warnings, ignored int)
 }
 
 type Formatter interface {
@@ -125,11 +125,11 @@ func (o *Stylish) Format(p lint.Problem) {
 	fmt.Fprintf(o.tw, "  (%d, %d)\t%s\t%s\n", pos.Line, pos.Column, p.Check, p.Message)
 }
 
-func (o *Stylish) Stats(total, errors, warnings int) {
+func (o *Stylish) Stats(total, errors, warnings, ignored int) {
 	if o.tw != nil {
 		o.tw.Flush()
 		fmt.Fprintln(o.W)
 	}
-	fmt.Fprintf(o.W, " ✖ %d problems (%d errors, %d warnings)\n",
-		total, errors, warnings)
+	fmt.Fprintf(o.W, " ✖ %d problems (%d errors, %d warnings, %d ignored)\n",
+		total, errors, warnings, ignored)
 }

--- a/lint/lintutil/util.go
+++ b/lint/lintutil/util.go
@@ -269,6 +269,7 @@ func ProcessFlagSet(cs []*analysis.Analyzer, cums []lint.CumulativeChecker, fs *
 		total    int
 		errors   int
 		warnings int
+		ignored  int
 	)
 
 	fail := *fs.Lookup("fail").Value.(*list)
@@ -286,6 +287,7 @@ func ProcessFlagSet(cs []*analysis.Analyzer, cums []lint.CumulativeChecker, fs *
 			continue
 		}
 		if p.Severity == lint.Ignored && !showIgnored {
+			ignored++
 			continue
 		}
 		if shouldExit[p.Check] {
@@ -297,7 +299,7 @@ func ProcessFlagSet(cs []*analysis.Analyzer, cums []lint.CumulativeChecker, fs *
 		f.Format(p)
 	}
 	if f, ok := f.(format.Statter); ok {
-		f.Stats(total, errors, warnings)
+		f.Stats(total, errors, warnings, ignored)
 	}
 	if errors > 0 {
 		exit(1)


### PR DESCRIPTION
Closes: #599 

This PR adds the list of ignored issues to the summary as requested in #599.
Output example:
```
$ ./staticcheck -f stylish ./...
/home/joseph/git/aerostitch/go-tools/go/types/typeutil/callee_test.go
  (66, 33)  SA1019  importer.For is deprecated: Use ForCompiler, which populates a FileSet with the positions of objects created by the importer. 
                                                    
 ✖ 12 problems (1 errors, 0 warnings, 11 ignored)
```

And if you use `-show-ignored` it will not have any ignored problems so the output would look like ` ✖ 12 problems (12 errors, 0 warnings, 0 ignored)` as you would expect.