### PR TITLE
doc: fix spacing issue for S1036 breaking the rendering

### DIFF
--- a/simple/doc.go
+++ b/simple/doc.go
@@ -438,27 +438,27 @@ receives a zero value. Often, the zero value is a suitable value, for example wh
 
 The following
 
-	if _, ok := m["foo"]; ok {
-		m["foo"] = append(m["foo"], "bar")
-	} else {
-		m["foo"] = []string{"bar"}
-	}
+    if _, ok := m["foo"]; ok {
+        m["foo"] = append(m["foo"], "bar")
+    } else {
+        m["foo"] = []string{"bar"}
+    }
 
 can be simplified to
 
-	m["foo"] = append(m["foo"], "bar")
+    m["foo"] = append(m["foo"], "bar")
 
 and
 
-	if _, ok := m2["k"]; ok {
-		m2["k"] += 4
-	} else {
-		m2["k"] = 4
-	}
+    if _, ok := m2["k"]; ok {
+        m2["k"] += 4
+    } else {
+        m2["k"] = 4
+    }
 
 can be simplified to
 
-	m["k"] += 4
+    m["k"] += 4
 `,
 		Since: "Unreleased",
 	},


### PR DESCRIPTION
Closes: #630 

Hi!

The problem was just that that section was having tabs instead of spaces.

Have a great day,
Joseph