### PR TITLE
Don't flag self–assignments with side effects

### DIFF
--- a/facts/purity.go
+++ b/facts/purity.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 
 	"golang.org/x/tools/go/analysis"
-	"honnef.co/go/tools/functions"
 	"honnef.co/go/tools/internal/passes/buildir"
 	"honnef.co/go/tools/ir"
 )
@@ -84,10 +83,6 @@ func purity(pass *analysis.Pass) (interface{}, error) {
 			}
 		}()
 
-		if functions.IsStub(fn) {
-			return false
-		}
-
 		if _, ok := pureStdlib[fn.Object().(*types.Func).FullName()]; ok {
 			return true
 		}
@@ -105,6 +100,7 @@ func purity(pass *analysis.Pass) (interface{}, error) {
 			}
 		}
 
+		// Don't consider external functions pure.
 		if fn.Blocks == nil {
 			return false
 		}

--- a/facts/testdata/src/Purity/CheckPureFunctions.go
+++ b/facts/testdata/src/Purity/CheckPureFunctions.go
@@ -7,8 +7,8 @@ func bar(a, b int) int {
 }
 
 func empty()            {}
-func stubPointer() *int { return nil }
-func stubInt() int      { return 0 }
+func stubPointer() *int { return nil } // want stubPointer:"is pure"
+func stubInt() int      { return 0 }   // want stubInt:"is pure"
 
 func fn3() {
 	empty()

--- a/functions/stub.go
+++ b/functions/stub.go
@@ -8,6 +8,10 @@ import (
 // considered a stub if it has no instructions or if all it does is
 // return a constant value.
 func IsStub(fn *ir.Function) bool {
+	// Don't consider external functions stubs.
+	if fn.Blocks == nil {
+		return false
+	}
 	for _, b := range fn.Blocks {
 		for _, instr := range b.Instrs {
 			switch instr.(type) {

--- a/staticcheck/analysis.go
+++ b/staticcheck/analysis.go
@@ -169,7 +169,7 @@ var Analyzers = lintutil.InitializeAnalyzers(Docs, map[string]*analysis.Analyzer
 	},
 	"SA4018": {
 		Run:      CheckSelfAssignment,
-		Requires: []*analysis.Analyzer{inspect.Analyzer, facts.Generated, facts.TokenFile},
+		Requires: []*analysis.Analyzer{inspect.Analyzer, facts.Generated, facts.TokenFile, facts.Purity},
 	},
 	"SA4019": {
 		Run:      CheckDuplicateBuildConstraints,

--- a/staticcheck/lint.go
+++ b/staticcheck/lint.go
@@ -2779,6 +2779,11 @@ fnLoop:
 					// TODO(dh): support anonymous functions
 					continue
 				}
+				// Ignore functions that we think aren't implemented yet or may
+				// be guarded by build tags. Avoids correct but useless reports.
+				if functions.IsStub(callee) {
+					continue
+				}
 				if _, ok := pure[callee.Object().(*types.Func)]; ok {
 					report.Report(pass, ins, fmt.Sprintf("%s is a pure function but its return value is ignored", callee.Name()))
 				}

--- a/staticcheck/testdata/src/CheckSelfAssignment/CheckSelfAssignment.go
+++ b/staticcheck/testdata/src/CheckSelfAssignment/CheckSelfAssignment.go
@@ -21,16 +21,22 @@ func fn1() {
 		x  []byte
 		ch chan int
 	)
-	x[pure()] = x[pure()] // want `self-assignment`
-	x[impure()] = x[impure()]
+	x[42] = x[42]                         // want `self-assignment`
+	x[pure(42)] = x[pure(42)]             // want `self-assignment`
+	x[pure(pure(42))] = x[pure(pure(42))] // want `self-assignment`
+	x[impure(42)] = x[impure(42)]
+	x[impure(pure(42))] = x[impure(pure(42))]
+	x[pure(impure(42))] = x[pure(impure(42))]
+	x[pure(<-ch)] = x[pure(<-ch)]
+	x[pure(pure(<-ch))] = x[pure(pure(<-ch))]
 	x[<-ch] = x[<-ch]
 }
 
-func pure() int {
-	return 0
+func pure(n int) int {
+	return n
 }
 
-func impure() int {
-	println()
-	return 0
+func impure(n int) int {
+	println(n)
+	return n
 }

--- a/staticcheck/testdata/src/CheckSelfAssignment/CheckSelfAssignment.go
+++ b/staticcheck/testdata/src/CheckSelfAssignment/CheckSelfAssignment.go
@@ -15,3 +15,22 @@ func fn(x int) {
 		println(x)
 	}()
 }
+
+func fn1() {
+	var (
+		x  []byte
+		ch chan int
+	)
+	x[pure()] = x[pure()] // want `self-assignment`
+	x[impure()] = x[impure()]
+	x[<-ch] = x[<-ch]
+}
+
+func pure() int {
+	return 0
+}
+
+func impure() int {
+	println()
+	return 0
+}


### PR DESCRIPTION
Fix SA4018 to not flag self–assignments of the form `x[e] = x[e]` where `e` may have side effects (e.g. a function call we know isn't pure or a channel read).

This also includes a change that unties the implementation of the purity fact from SA4017, making it available for reuse in SA4018 and potentially other checks in the future.