### PR TITLE
facts: handle overlapping prefix/suffix

### DIFF
--- a/facts/generated.go
+++ b/facts/generated.go
@@ -25,7 +25,7 @@ var (
 	// used by cgo before Go 1.11
 	oldCgo = []byte("// Created by cgo - DO NOT EDIT")
 	prefix = []byte("// Code generated ")
-	suffix = []byte("DO NOT EDIT.")
+	suffix = []byte(" DO NOT EDIT.")
 	nl     = []byte("\n")
 	crnl   = []byte("\r\n")
 )
@@ -45,14 +45,19 @@ func isGenerated(path string) (Generator, bool) {
 		s = bytes.TrimSuffix(s, crnl)
 		s = bytes.TrimSuffix(s, nl)
 		if bytes.HasPrefix(s, prefix) && bytes.HasSuffix(s, suffix) {
+			if len(s)-len(suffix) < len(prefix) {
+				return Unknown, true
+			}
+
 			text := string(s[len(prefix) : len(s)-len(suffix)])
 
-			if strings.HasPrefix(text, "by goyacc.") {
+			switch text {
+			case "by goyacc.":
 				return Goyacc, true
-			}
-			if strings.HasPrefix(text, "by cmd/cgo;") {
+			case "by cmd/cgo;":
 				return Cgo, true
 			}
+
 			if strings.HasPrefix(text, `by "stringer `) {
 				return Stringer, true
 			}

--- a/facts/generated.go
+++ b/facts/generated.go
@@ -25,7 +25,7 @@ var (
 	// used by cgo before Go 1.11
 	oldCgo = []byte("// Created by cgo - DO NOT EDIT")
 	prefix = []byte("// Code generated ")
-	suffix = []byte(" DO NOT EDIT.")
+	suffix = []byte("DO NOT EDIT.")
 	nl     = []byte("\n")
 	crnl   = []byte("\r\n")
 )
@@ -46,10 +46,11 @@ func isGenerated(path string) (Generator, bool) {
 		s = bytes.TrimSuffix(s, nl)
 		if bytes.HasPrefix(s, prefix) && bytes.HasSuffix(s, suffix) {
 			text := string(s[len(prefix) : len(s)-len(suffix)])
-			switch text {
-			case "by goyacc.":
+
+			if strings.HasPrefix(text, "by goyacc.") {
 				return Goyacc, true
-			case "by cmd/cgo;":
+			}
+			if strings.HasPrefix(text, "by cmd/cgo;") {
 				return Cgo, true
 			}
 			if strings.HasPrefix(text, `by "stringer `) {


### PR DESCRIPTION
We have a generated file which starts with the comment:

```
// Code generated DO NOT EDIT.
```

This causes staticcheck to panic, because we have an overlapping prefix and
suffix when checking for these magic strings, i.e.:

```
"// Code generated "
                 " DO NOT EDIT."
```

Trying to take a slice where end is before start subsequently panics.

```
panic: runtime error: slice bounds out of range [18:17]

goroutine 2028 [running]:
honnef.co/go/tools/facts.isGenerated(0xc000b52410, 0x4e, 0x0, 0xc000b52400)
	/go/src/honnef.co/go/tools/facts/generated.go:48 +0x895
honnef.co/go/tools/facts.glob..func1(0xc00ae3e000, 0xd02a5be9, 0xf86f40, 0x20, 0x7f9a88181200)
	/go/src/honnef.co/go/tools/facts/generated.go:81 +0xf1
honnef.co/go/tools/lint.(*Runner).runAnalysisUser(0xc00020f900, 0xc00ae3e000, 0xc00ad80730, 0xc00a5a4a00, 0xc005100a20, 0xc00a5a4a20, 0xc005100a80)
	/go/src/honnef.co/go/tools/lint/runner.go:494 +0x2af
honnef.co/go/tools/lint.(*Runner).runAnalysis(0xc00020f900, 0xc00ad80730, 0x0, 0x0, 0x0, 0x0)
	/go/src/honnef.co/go/tools/lint/runner.go:374 +0x574
honnef.co/go/tools/lint.(*Runner).processPkg.func3(0xc00fb87e70, 0xc00054dc20, 0xf7c320, 0xc00020f900, 0xc00ad80730, 0xc00adba540, 0x6, 0x6, 0x2)
	/go/src/honnef.co/go/tools/lint/runner.go:913 +0x79
created by honnef.co/go/tools/lint.(*Runner).processPkg
	/go/src/honnef.co/go/tools/lint/runner.go:908 +0x9f3
```

This commit makes the "parse" non-overlapping, at the cost of replacing the
text switch lookup with `strings.HasPrefix`. A plausible alternative would
be to do an explicit bounds test instead - I haven't bothered thinking too
hard / benching these, though.