### PR TITLE
Initial support for custom analyzers.

### DIFF
--- a/cmd/staticcheck/staticcheck.go
+++ b/cmd/staticcheck/staticcheck.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"golang.org/x/tools/go/analysis"
+	"honnef.co/go/tools/custom"
 	"honnef.co/go/tools/lint"
 	"honnef.co/go/tools/lint/lintutil"
 	"honnef.co/go/tools/simple"
@@ -18,6 +19,7 @@ func main() {
 	fs := lintutil.FlagSet("staticcheck")
 	wholeProgram := fs.Bool("unused.whole-program", false, "Run unused in whole program mode")
 	debug := fs.String("debug.unused-graph", "", "Write unused's object graph to `file`")
+	pluginPath := fs.String("custom-analyzers", "", "Run custom analyzers from a go plugin")
 	fs.Parse(os.Args[1:])
 
 	var cs []*analysis.Analyzer
@@ -29,6 +31,15 @@ func main() {
 	}
 	for _, v := range stylecheck.Analyzers {
 		cs = append(cs, v)
+	}
+	if *pluginPath != "" {
+		customAnalyzers, err := custom.Analyzers(*pluginPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, v := range customAnalyzers {
+			cs = append(cs, v)
+		}
 	}
 
 	u := unused.NewChecker(*wholeProgram)

--- a/custom/analysis.go
+++ b/custom/analysis.go
@@ -19,7 +19,7 @@ func Analyzers(pluginPath string) (result map[string]*analysis.Analyzer, _ error
 	}
 	analyzers, ok := analyzersSymbol.(*map[string]*analysis.Analyzer)
 	if !ok {
-		return nil, fmt.Errorf("Analyzers must be of type %T, not %T.", result, analyzers)
+		return nil, fmt.Errorf("analyzers must be of type %T, not %T", result, analyzers)
 	}
 	return *analyzers, nil
 }

--- a/custom/analysis.go
+++ b/custom/analysis.go
@@ -1,0 +1,25 @@
+package custom
+
+import (
+	"fmt"
+	"plugin"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// Analyzers opens the plugin at pluginPath and returns the Analyzers it contains.
+func Analyzers(pluginPath string) (result map[string]*analysis.Analyzer, _ error) {
+	p, err := plugin.Open(pluginPath)
+	if err != nil {
+		return nil, err
+	}
+	analyzersSymbol, err := p.Lookup("Analyzers")
+	if err != nil {
+		return nil, err
+	}
+	analyzers, ok := analyzersSymbol.(*map[string]*analysis.Analyzer)
+	if !ok {
+		return nil, fmt.Errorf("Analyzers must be of type %T, not %T.", result, analyzers)
+	}
+	return *analyzers, nil
+}


### PR DESCRIPTION
This PR adds support for users to add custom analyzers using go plugins. I personally have a need for this feature as I maintain project that uses staticcheck and would like to be able to add custom checks to our CI process that don't make sense as general static checks. By way of example this is what the plugin code winds up looking like:

```golang
package main

import (
	"golang.org/x/tools/go/analysis"

	"honnef.co/go/tools/code"
	"honnef.co/go/tools/internal/passes/buildir"
	"honnef.co/go/tools/ir"
	"honnef.co/go/tools/lint"
	"honnef.co/go/tools/lint/lintutil"
	"honnef.co/go/tools/report"
)

var Docs = map[string]*lint.Documentation{
	"SC1000": {
		Title: "Use of fmt.Errorf",
		Text:  "Don't use fmt.Errorf because it doesn't attach a stacktrace, use errors.Errorf instead.",
		Since: "2020.3",
	},
}

var Analyzers = lintutil.InitializeAnalyzers(Docs, map[string]*analysis.Analyzer{
	"SC1000": {
		Run:      NoFmtErrorf,
		Requires: []*analysis.Analyzer{buildir.Analyzer},
	},
})

func NoFmtErrorf(pass *analysis.Pass) (interface{}, error) {
	for _, fn := range pass.ResultOf[buildir.Analyzer].(*buildir.IR).SrcFuncs {
		if code.IsInTest(pass, fn) {
			// We don't care about malformed error messages in tests;
			// they're usually for direct human consumption, not part
			// of an API
			continue
		}
		for _, block := range fn.Blocks {
			for _, ins := range block.Instrs {
				call, ok := ins.(*ir.Call)
				if !ok {
					continue
				}
				if code.IsCallTo(call.Common(), "fmt.Errorf") {
					report.Report(pass, call, "use errors.Errorf")
				}
			}
		}
	}
	return nil, nil
}
```

This one just checks for uses of `fmt.Errorf` (we outlaw that because it doesn't include stacktraces). To build this you do `go build -buildmode=plugin <path>`.

I've tried to respect the code standards I saw within the project but I'm sure there's some things I've missed, if this is something that maintainers are interested in merging I'm happy to clean anything up that doesn't meet your standards.

Thanks for making great go tools.