### PR TITLE
[SA1012] Fix tests for suggested fixes

### DIFF
--- a/staticcheck/testdata/src/checkStdlibUsageNilContext/checkStdlibUsageNilContext.go.golden
+++ b/staticcheck/testdata/src/checkStdlibUsageNilContext/checkStdlibUsageNilContext.go.golden
@@ -1,3 +1,4 @@
+-- use context.Background --
 package pkg
 
 import "context"
@@ -12,6 +13,31 @@ func (*T) Foo() {}
 
 func fn3() {
 	fn1(context.Background()) // want `do not pass a nil Context`
+	fn1(context.TODO())
+	fn2("", nil)
+	fn4()
+
+	// don't flag this conversion
+	_ = (func(context.Context))(nil)
+	// and don't crash on these
+	_ = (func())(nil)
+	(*T).Foo(nil)
+}
+-- use context.TODO --
+package pkg
+
+import "context"
+
+func fn1(ctx context.Context)           {}
+func fn2(x string, ctx context.Context) {}
+func fn4()                              {}
+
+type T struct{}
+
+func (*T) Foo() {}
+
+func fn3() {
+	fn1(context.TODO()) // want `do not pass a nil Context`
 	fn1(context.TODO())
 	fn2("", nil)
 	fn4()


### PR DESCRIPTION
The entire package in `bool-cmp` dir was being loaded twice by `analysistest.Run` -- once while loading the package itself, and again as a test package. This resulted in the fixes running on the package in the same files twice. `bool-cmp_test.go` wasn't serving any purpose in the package, hence this commit removes it.

Also, the golden file for the test of SA1012 was partial. This commit fixes that.

Signed-off-by: Sourya Vatsyayan <sourya@deepsource.io>