### PR TITLE
staticcheck: add config for error_funcitons (fmt.Errorf, errors.New)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -128,6 +128,9 @@ func (cfg Config) Merge(ocfg Config) Config {
 	if ocfg.HTTPStatusCodeWhitelist != nil {
 		cfg.HTTPStatusCodeWhitelist = mergeLists(cfg.HTTPStatusCodeWhitelist, ocfg.HTTPStatusCodeWhitelist)
 	}
+	if ocfg.ErrorFunctions != nil {
+		cfg.ErrorFunctions = mergeLists(cfg.ErrorFunctions, ocfg.ErrorFunctions)
+	}
 	return cfg
 }
 
@@ -143,6 +146,7 @@ type Config struct {
 	Initialisms             []string `toml:"initialisms"`
 	DotImportWhitelist      []string `toml:"dot_import_whitelist"`
 	HTTPStatusCodeWhitelist []string `toml:"http_status_code_whitelist"`
+	ErrorFunctions          []string `toml:"error_functions"`
 }
 
 func (c Config) String() string {
@@ -151,7 +155,8 @@ func (c Config) String() string {
 	fmt.Fprintf(buf, "Checks: %#v\n", c.Checks)
 	fmt.Fprintf(buf, "Initialisms: %#v\n", c.Initialisms)
 	fmt.Fprintf(buf, "DotImportWhitelist: %#v\n", c.DotImportWhitelist)
-	fmt.Fprintf(buf, "HTTPStatusCodeWhitelist: %#v", c.HTTPStatusCodeWhitelist)
+	fmt.Fprintf(buf, "HTTPStatusCodeWhitelist: %#v\n", c.HTTPStatusCodeWhitelist)
+	fmt.Fprintf(buf, "ErrorFunctions: %#v\n", c.ErrorFunctions)
 
 	return buf.String()
 }
@@ -169,6 +174,7 @@ var DefaultConfig = Config{
 	},
 	DotImportWhitelist:      []string{},
 	HTTPStatusCodeWhitelist: []string{"200", "400", "404", "500"},
+	ErrorFunctions:          []string{"errors.New", "fmt.Errorf"},
 }
 
 const ConfigName = "staticcheck.conf"
@@ -240,6 +246,7 @@ func Load(dir string) (Config, error) {
 	conf.Initialisms = normalizeList(conf.Initialisms)
 	conf.DotImportWhitelist = normalizeList(conf.DotImportWhitelist)
 	conf.HTTPStatusCodeWhitelist = normalizeList(conf.HTTPStatusCodeWhitelist)
+	conf.ErrorFunctions = normalizeList(conf.ErrorFunctions)
 
 	return conf, nil
 }

--- a/config/example.conf
+++ b/config/example.conf
@@ -8,3 +8,4 @@ initialisms = ["ACL", "API", "ASCII", "CPU", "CSS", "DNS",
 	"XSS", "SIP", "RTP"]
 dot_import_whitelist = []
 http_status_code_whitelist = ["200", "400", "404", "500"]
+error_functions = ["errors.New", "fmt.Errorf"]

--- a/go/ir/irutil/util.go
+++ b/go/ir/irutil/util.go
@@ -75,7 +75,7 @@ func Vararg(x *ir.Slice) ([]ir.Value, bool) {
 
 func CallName(call *ir.CallCommon) string {
 	if call.IsInvoke() {
-		return ""
+		return call.Method.FullName()
 	}
 	switch v := call.Value.(type) {
 	case *ir.Function:
@@ -94,6 +94,9 @@ func IsCallTo(call *ir.CallCommon, name string) bool { return CallName(call) == 
 
 func IsCallToAny(call *ir.CallCommon, names ...string) bool {
 	q := CallName(call)
+	if q == "" {
+		return false
+	}
 	for _, name := range names {
 		if q == name {
 			return true

--- a/stylecheck/analysis.go
+++ b/stylecheck/analysis.go
@@ -24,7 +24,7 @@ var Analyzers = lint.InitializeAnalyzers(Docs, map[string]*analysis.Analyzer{
 	},
 	"ST1005": {
 		Run:      CheckErrorStrings,
-		Requires: []*analysis.Analyzer{buildir.Analyzer},
+		Requires: []*analysis.Analyzer{buildir.Analyzer, config.Analyzer},
 	},
 	"ST1006": {
 		Run:      CheckReceiverNames,
@@ -39,7 +39,8 @@ var Analyzers = lint.InitializeAnalyzers(Docs, map[string]*analysis.Analyzer{
 		Requires: []*analysis.Analyzer{inspect.Analyzer},
 	},
 	"ST1012": {
-		Run: CheckErrorVarNames,
+		Run:      CheckErrorVarNames,
+		Requires: []*analysis.Analyzer{config.Analyzer},
 	},
 	"ST1013": {
 		Run: CheckHTTPStatusCodes,


### PR DESCRIPTION
Add a list of error functions (`fmt.Errorf`, ʻerrors.New`) to the config file.
This useful for checking custom error functions/methods.

For example:
`staticcheck.conf`
```
error_functions = ["errors.New", "fmt.Errorf", "myproject/logger.Errorf", "(myproject/logger.Logger).Errorf"]
```

`main.go`
```go
package main

import (
	"myproject/logger"
)

func main() {
	logger.Errorf("Failed to")

	l := logger.New()
	l.Errorf("Failed to")
}
```

`logger/logger.go`
```go
package logger

func Errorf(format string, v ...interface{}) {
	//
}

type Logger struct{}

func (l Logger) Errorf(format string, v ...interface{}) {
	//
}

func New() *Logger {
	return &Logger{}
}
```