### PR TITLE
simple: fix negate for GEQ from LEQ to LSS

### DIFF
--- a/simple/lint.go
+++ b/simple/lint.go
@@ -470,7 +470,7 @@ func negate(expr ast.Expr) ast.Expr {
 		case token.LEQ:
 			out.Op = token.GTR
 		case token.GEQ:
-			out.Op = token.LEQ
+			out.Op = token.LSS
 		}
 		return &out
 	case *ast.Ident, *ast.CallExpr, *ast.IndexExpr:


### PR DESCRIPTION
The negative for >= should be < but not <=
issue: #874 