### PR TITLE
staticcheck CheckLoopCondition: test multiple variable declarations

### DIFF
--- a/staticcheck/testdata/src/CheckLoopCondition/CheckLoopCondition.go
+++ b/staticcheck/testdata/src/CheckLoopCondition/CheckLoopCondition.go
@@ -13,4 +13,7 @@ func fn() {
 			*x++
 		}
 	}
+
+	for i, x := 0, 0; i < 10; x++ { // want `variable in loop condition never changes`
+	}
 }


### PR DESCRIPTION
This is currently not flagged but probably should be. See:

https://github.com/dominikh/go-tools/issues/887


This is a failing test, in case it helps with the above issue. Feel free to close if this is not helpful! Thank you!