### PR TITLE
SA4020: fix false positive for nil in a case statement

### DIFF
--- a/staticcheck/lint.go
+++ b/staticcheck/lint.go
@@ -3567,9 +3567,12 @@ func CheckUnreachableTypeCases(pass *analysis.Pass) (interface{}, error) {
 				continue
 			}
 
-			Ts := make([]types.Type, len(cc.List))
-			for i, expr := range cc.List {
-				Ts[i] = pass.TypesInfo.TypeOf(expr)
+			Ts := make([]types.Type, 0, len(cc.List))
+			for _, expr := range cc.List {
+				// Exclude the 'nil' value from any 'case' statement (it is always reachable).
+				if typ := pass.TypesInfo.TypeOf(expr); typ != types.Typ[types.UntypedNil] {
+					Ts = append(Ts, typ)
+				}
 			}
 
 			ccs = append(ccs, ccAndTypes{cc: cc, types: Ts})

--- a/staticcheck/testdata/src/CheckUnreachableTypeCases/CheckUnreachableTypeCases.go
+++ b/staticcheck/testdata/src/CheckUnreachableTypeCases/CheckUnreachableTypeCases.go
@@ -62,6 +62,13 @@ func fn1() {
 		println("T")
 	}
 
+	switch v.(type) {
+	case interface{}:
+		println("interface{}")
+	case nil, T: // want `unreachable case clause: interface{} will always match before CheckUnreachableTypeCases\.T`
+		println("nil or T")
+	}
+
 	switch err.(type) {
 	case V:
 		println("V")
@@ -119,5 +126,12 @@ func fn3() {
 	switch v.(type) {
 	default:
 		println("something")
+	}
+
+	switch v.(type) {
+	case interface{}:
+		println("interface{}")
+	case nil:
+		println("nil")
 	}
 }


### PR DESCRIPTION
Consider this program:

```go
package main

func main() {
	var x interface{}
	switch x.(type) {
	case interface{}:
		println("This is interface{}")
	case nil:
		println("This is nil")
	}
}
```
the output of execution is correct:
```
This is nil
```

But running `staticcheck` built from a [current master](https://github.com/dominikh/go-tools/tree/903cdb5ed2f937fbf4004274aa4654317f193bc4) reports false-positive:

```
main.go:8:2: unreachable case clause: interface{} will always match before untyped nil (SA4020)
```

With changes introduced in this PR, `statickcheck` won't complain about such a case.