### PR TITLE
Add support for IncDecStmt in arg overwrite

### DIFF
--- a/staticcheck/lint.go
+++ b/staticcheck/lint.go
@@ -2061,16 +2061,18 @@ func CheckArgOverwritten(pass *analysis.Pass) (interface{}, error) {
 						if assignment != nil {
 							return false
 						}
-						assign, ok := node.(*ast.AssignStmt)
-						if !ok {
-							return true
-						}
-						for _, lhs := range assign.Lhs {
-							ident, ok := lhs.(*ast.Ident)
-							if !ok {
-								continue
+						switch assign := node.(type) {
+						case *ast.AssignStmt:
+							for _, lhs := range assign.Lhs {
+								ident, ok := lhs.(*ast.Ident)
+								if ok && pass.TypesInfo.ObjectOf(ident) == obj {
+									assignment = assign
+									return false
+								}
 							}
-							if pass.TypesInfo.ObjectOf(ident) == obj {
+						case *ast.IncDecStmt:
+							ident, ok := assign.X.(*ast.Ident)
+							if ok && pass.TypesInfo.ObjectOf(ident) == obj {
 								assignment = assign
 								return false
 							}

--- a/staticcheck/lint_test.go
+++ b/staticcheck/lint_test.go
@@ -55,7 +55,7 @@ func TestAll(t *testing.T) {
 		"SA4004": {{Dir: "CheckIneffectiveLoop"}},
 		"SA4006": {{Dir: "CheckUnreadVariableValues"}},
 		"SA4008": {{Dir: "CheckLoopCondition"}},
-		"SA4009": {{Dir: "CheckArgOverwritten"}},
+		"SA4009": {{Dir: "CheckArgOverwritten"}, {Dir: "CheckArgOverwrittenIncrementOperator"}},
 		"SA4010": {{Dir: "CheckIneffectiveAppend"}},
 		"SA4011": {{Dir: "CheckScopedBreak"}},
 		"SA4012": {{Dir: "CheckNaNComparison"}},

--- a/staticcheck/testdata/src/CheckArgOverwrittenIncrementOperator/CheckArgOverwritten.go
+++ b/staticcheck/testdata/src/CheckArgOverwrittenIncrementOperator/CheckArgOverwritten.go
@@ -1,0 +1,6 @@
+package pkg
+
+var x = func(arg int) { // want `overwritten`
+	arg++
+	println(arg)
+}


### PR DESCRIPTION
I think it straight forward but consider this example:

```
func retry(fn func() error, retries int) error {
	for {
		if err := fn(); err != nil {
			if retries < 1 {
				return err
			}
			retries--
			continue
		}
		return nil
	}
}
```
The linter doesn't flag `retries--`