### PR TITLE
S1008: avoid double-negation

### DIFF
--- a/simple/lint.go
+++ b/simple/lint.go
@@ -473,7 +473,7 @@ func negate(expr ast.Expr) ast.Expr {
 			out.Op = token.LSS
 		}
 		return &out
-	case *ast.Ident, *ast.CallExpr, *ast.IndexExpr:
+	case *ast.Ident, *ast.CallExpr, *ast.IndexExpr, *ast.StarExpr:
 		return &ast.UnaryExpr{
 			Op: token.NOT,
 			X:  expr,
@@ -482,14 +482,18 @@ func negate(expr ast.Expr) ast.Expr {
 		if expr.Op == token.NOT {
 			return expr.X
 		}
+		return &ast.UnaryExpr{
+			Op: token.NOT,
+			X:  expr,
+		}
+	default:
+		return &ast.UnaryExpr{
+			Op: token.NOT,
+			X: &ast.ParenExpr{
+				X: expr,
+			},
+		}
 	}
-	return &ast.UnaryExpr{
-		Op: token.NOT,
-		X: &ast.ParenExpr{
-			X: expr,
-		},
-	}
-
 }
 
 // CheckRedundantNilCheckWithLen checks for the following redundant nil-checks:

--- a/simple/lint.go
+++ b/simple/lint.go
@@ -478,14 +478,18 @@ func negate(expr ast.Expr) ast.Expr {
 			Op: token.NOT,
 			X:  expr,
 		}
-	default:
-		return &ast.UnaryExpr{
-			Op: token.NOT,
-			X: &ast.ParenExpr{
-				X: expr,
-			},
+	case *ast.UnaryExpr:
+		if expr.Op == token.NOT {
+			return expr.X
 		}
 	}
+	return &ast.UnaryExpr{
+		Op: token.NOT,
+		X: &ast.ParenExpr{
+			X: expr,
+		},
+	}
+
 }
 
 // CheckRedundantNilCheckWithLen checks for the following redundant nil-checks:

--- a/simple/testdata/src/if-return/if-return.go
+++ b/simple/testdata/src/if-return/if-return.go
@@ -100,3 +100,10 @@ func fn14(a, b int) bool {
 	}
 	return true
 }
+
+func fn15() bool {
+	if !fn() { // want `should use 'return fn\(\)'`
+		return false
+	}
+	return true
+}

--- a/simple/testdata/src/if-return/if-return.go
+++ b/simple/testdata/src/if-return/if-return.go
@@ -107,3 +107,28 @@ func fn15() bool {
 	}
 	return true
 }
+
+func fn16() <-chan bool {
+	x := make(chan bool, 1)
+	x <- true
+	return x
+}
+
+func fn17() bool {
+	if <-fn16() { // want `should use 'return !<-fn16\(\)'`
+		return false
+	}
+	return true
+}
+
+func fn18() *bool {
+	x := true
+	return &x
+}
+
+func fn19() bool {
+	if *fn18() { // want `should use 'return !\*fn18\(\)'`
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
Pretty simple one. Given
```
if !fn() {
	return false
}
return true
```

We suggest `return fn()` instead of `return !(!fn())`.

Resolves #830