### PR TITLE
Spelling

### DIFF
--- a/analysis/code/code.go
+++ b/analysis/code/code.go
@@ -209,7 +209,7 @@ func MayHaveSideEffects(pass *analysis.Pass, expr ast.Expr, purity facts.PurityR
 	case *ast.Ellipsis:
 		return MayHaveSideEffects(pass, expr.Elt, purity)
 	case *ast.FuncLit:
-		// the literal itself cannot have side ffects, only calling it
+		// the literal itself cannot have side effects, only calling it
 		// might, which is handled by CallExpr.
 		return false
 	case *ast.ArrayType, *ast.StructType, *ast.FuncType, *ast.InterfaceType, *ast.MapType, *ast.ChanType:

--- a/analysis/lint/lint.go
+++ b/analysis/lint/lint.go
@@ -169,7 +169,7 @@ func parseDirective(s string) (cmd string, args []string) {
 func ParseDirectives(files []*ast.File, fset *token.FileSet) []Directive {
 	var dirs []Directive
 	for _, f := range files {
-		// OPT(dh): in our old code, we skip all the commentmap work if we
+		// OPT(dh): in our old code, we skip all the comment map work if we
 		// couldn't find any directives, benchmark if that's actually
 		// worth doing
 		cm := ast.NewCommentMap(fset, f, f.Comments)

--- a/go/ir/builder.go
+++ b/go/ir/builder.go
@@ -2119,7 +2119,7 @@ start:
 		fn.emit(&v, s)
 
 	case *ast.ReturnStmt:
-		// TODO(dh): we could emit tigher position information by
+		// TODO(dh): we could emit tighter position information by
 		// using the ith returned expression
 
 		var results []Value

--- a/go/ir/doc.go
+++ b/go/ir/doc.go
@@ -31,7 +31,7 @@
 //
 // The builder initially builds a naive IR form in which all local
 // variables are addresses of stack locations with explicit loads and
-// stores.  Registerisation of eligible locals and φ-node insertion
+// stores.  Registerization of eligible locals and φ-node insertion
 // using dominance and dataflow are then performed as a second pass
 // called "lifting" to improve the accuracy and performance of
 // subsequent analyses; this pass can be skipped by setting the

--- a/go/ir/html.go
+++ b/go/ir/html.go
@@ -734,7 +734,7 @@ Values printed in italics have a dependency cycle.
 
 <p>
 <b>CFG</b>: Dashed edge is for unlikely branches. Blue color is for backward edges.
-Edge with a dot means that this edge follows the order in which blocks were laidout.
+Edge with a dot means that this edge follows the order in which blocks were laid out.
 </p>
 
 </div>

--- a/go/loader/loader.go
+++ b/go/loader/loader.go
@@ -26,7 +26,7 @@ type PackageSpec struct {
 	ID      string
 	Name    string
 	PkgPath string
-	// Errors that occured while building the import graph. These will
+	// Errors that occurred while building the import graph. These will
 	// primarily be parse errors or failure to resolve imports, but
 	// may also be other errors.
 	Errors          []packages.Error
@@ -49,7 +49,7 @@ func (spec *PackageSpec) String() string {
 type Package struct {
 	*PackageSpec
 
-	// Errors that occured while loading the package. These will
+	// Errors that occurred while loading the package. These will
 	// primarily be parse or type errors, but may also be lower-level
 	// failures such as file-system ones.
 	Errors    []packages.Error

--- a/internal/gosmith/context.go
+++ b/internal/gosmith/context.go
@@ -509,7 +509,7 @@ thisPackage:
 }
 
 func (smith *Smith) materializeGotoLabel() string {
-	// TODO: move lavel up
+	// TODO: move label up
 	id := smith.newId("Label")
 
 	curBlock0 := smith.curBlock

--- a/internal/gosmith/stmt.go
+++ b/internal/gosmith/stmt.go
@@ -443,7 +443,7 @@ func (smith *Smith) stmtContinue() {
 }
 
 func (smith *Smith) stmtGoto() {
-	// TODO: suppport goto down
+	// TODO: support goto down
 	id := smith.materializeGotoLabel()
 	smith.line("goto %v", id)
 }

--- a/internal/gosmith/stmt.go
+++ b/internal/gosmith/stmt.go
@@ -348,18 +348,18 @@ func (smith *Smith) stmtSwitchExpr() {
 	}
 	// TODO: we generate at most one case, because if we generate more,
 	// we can generate two cases with equal constants.
-	fallth := false
+	fallthru := false
 	if smith.rndBool() {
 		smith.enterBlock(true)
 		smith.line("case %v:", smith.rvalue(t))
 		smith.genBlock()
 		smith.leaveBlock()
 		if smith.rndBool() {
-			fallth = true
+			fallthru = true
 			smith.line("fallthrough")
 		}
 	}
-	if fallth || len(vars) > 0 || smith.rndBool() {
+	if fallthru || len(vars) > 0 || smith.rndBool() {
 		smith.enterBlock(true)
 		smith.line("default:")
 		smith.genBlock()

--- a/internal/gosmith/type.go
+++ b/internal/gosmith/type.go
@@ -43,7 +43,7 @@ type Type struct {
 	utyp           *Type   // underlying type
 	styp           []*Type // function arguments
 	rtyp           []*Type // function return values
-	elems          []*Var  // struct fileds and interface methods
+	elems          []*Var  // struct fields and interface methods
 	literal        func() string
 	complexLiteral func() string
 

--- a/lintcmd/cmd.go
+++ b/lintcmd/cmd.go
@@ -217,7 +217,7 @@ func success(allowedChecks map[string]bool, res runner.ResultData) []problem {
 }
 
 func filterIgnored(problems []problem, res runner.ResultData, allowedAnalyzers map[string]bool) ([]problem, error) {
-	couldveMatched := func(ig *lineIgnore) bool {
+	couldHaveMatched := func(ig *lineIgnore) bool {
 		for _, c := range ig.Checks {
 			if c == "U1000" {
 				// We never want to flag ignores for U1000,
@@ -253,7 +253,7 @@ func filterIgnored(problems []problem, res runner.ResultData, allowedAnalyzers m
 			}
 		}
 
-		if ig, ok := ig.(*lineIgnore); ok && !ig.Matched && couldveMatched(ig) {
+		if ig, ok := ig.(*lineIgnore); ok && !ig.Matched && couldHaveMatched(ig) {
 			p := problem{
 				Diagnostic: runner.Diagnostic{
 					Position: ig.Pos,

--- a/lintcmd/runner/runner.go
+++ b/lintcmd/runner/runner.go
@@ -644,7 +644,7 @@ func (r *subrunner) doUncached(a *packageAction) (packageActionResult, error) {
 	}
 
 	if len(pkg.Errors) > 0 {
-		// this handles errors that occured during type-checking the
+		// this handles errors that occurred during type-checking the
 		// package in loader.Load
 		for _, err := range pkg.Errors {
 			a.errors = append(a.errors, err)

--- a/lintcmd/runner/runner.go
+++ b/lintcmd/runner/runner.go
@@ -104,7 +104,7 @@ package runner
 // of time.
 //
 // We would likely need to do extensive benchmarking to figure out how
-// long to keep data around to find a sweetspot where we reduce CPU
+// long to keep data around to find a sweet spot where we reduce CPU
 // load without increasing memory usage.
 //
 // We can probably populate the cache after we've analyzed a package,

--- a/simple/lint.go
+++ b/simple/lint.go
@@ -1879,7 +1879,7 @@ var checkSprintLiteralQ = pattern.MustParse(`
 func CheckSprintLiteral(pass *analysis.Pass) (interface{}, error) {
 	// We only flag calls with string literals, not expressions of
 	// type string, because some people use fmt.Sprint(s) as a pattern
-	// for copying strings, which may be useful when extracing a small
+	// for copying strings, which may be useful when extracting a small
 	// substring from a large string.
 	fn := func(node ast.Node) {
 		m, ok := code.Match(pass, checkSprintLiteralQ, node)

--- a/staticcheck/doc.go
+++ b/staticcheck/doc.go
@@ -644,7 +644,7 @@ As a consequence, the following code pattern is an expensive no-op:
 	},
 
 	"SA5001": {
-		Title: "Defering `Close` before checking for a possible error",
+		Title: "Deferring `Close` before checking for a possible error",
 		Since: "2017.1",
 	},
 

--- a/staticcheck/doc.go
+++ b/staticcheck/doc.go
@@ -1041,7 +1041,7 @@ For instance:
 
 will always result in 0.
 
-This check flags bit shifiting operations on fixed size integer values only.
+This check flags bit shifting operations on fixed size integer values only.
 That is, int, uint and uintptr are never flagged to avoid potential false
 positives in somewhat exotic but valid bit twiddling tricks:
 

--- a/staticcheck/doc.go
+++ b/staticcheck/doc.go
@@ -164,7 +164,7 @@ return all results, specify a negative number.`,
 
 	"SA1016": {
 		Title: `Trapping a signal that cannot be trapped`,
-		Text: `Not all signals can be intercepted by a process. Speficially, on
+		Text: `Not all signals can be intercepted by a process. Specifically, on
 UNIX-like systems, the \'syscall.SIGKILL\' and \'syscall.SIGSTOP\' signals are
 never passed to the process, but instead handled directly by the
 kernel. It is therefore pointless to try and handle these signals.`,

--- a/staticcheck/lint.go
+++ b/staticcheck/lint.go
@@ -4191,7 +4191,7 @@ func findIndirectSliceLenChecks(pass *analysis.Pass) {
 					// parameter, because Params is not populated for
 					// external functions. In our modular analysis.
 					// any function in any package that isn't the
-					// current package is consided "external", as it
+					// current package is considered "external", as it
 					// has been loaded from export data only.
 					sigParams := callee.Signature.Params()
 

--- a/staticcheck/lint.go
+++ b/staticcheck/lint.go
@@ -2998,7 +2998,7 @@ func CheckDeprecated(pass *analysis.Pass) (interface{}, error) {
 			return true
 		}
 		if depr, ok := deprs.Objects[obj]; ok {
-			// Note: gopls dosn't correctly run analyzers on
+			// Note: gopls doesn't correctly run analyzers on
 			// dependencies, so we'll never be able to find deprecated
 			// objects in imported code. We've experimented with
 			// lifting the stdlib handling out of the general check,

--- a/unused/testdata/src/ignored/ignored.go
+++ b/unused/testdata/src/ignored/ignored.go
@@ -41,7 +41,7 @@ type t6 interface { // used
 	foo() // used
 }
 
-//lint:ignore U1000 cpnsider yourself used
+//lint:ignore U1000 consider yourself used
 type t7 = struct { // used
 	z int // used
 }

--- a/unused/typemap/map_test.go
+++ b/unused/typemap/map_test.go
@@ -92,12 +92,12 @@ func TestMap(t *testing.T) {
 		}
 	})
 
-	// Setion with key equal to present one.
+	// Section with key equal to present one.
 	if prev := tmap.Set(tPStr2, "*string again"); prev != "*string" {
 		t.Errorf("Set() previous value: got %s, want \"*string\"", prev)
 	}
 
-	// Setion of another association.
+	// Section of another association.
 	if prev := tmap.Set(tChanInt1, "<-chan int"); prev != nil {
 		t.Errorf("Set() previous value: got %s, want nil", prev)
 	}

--- a/unused/unused.go
+++ b/unused/unused.go
@@ -1553,7 +1553,7 @@ func (g *graph) instructions(fn *ir.Function) {
 			case *ir.Slice:
 				// nothing to do, handled generically by operands
 			case *ir.RunDefers:
-				// nothing to do, the deferred functions are already marked use by defering them.
+				// nothing to do, the deferred functions are already marked use by deferring them.
 			case *ir.Convert:
 				// to unsafe.Pointer
 				if typ, ok := instr.Type().(*types.Basic); ok && typ.Kind() == types.UnsafePointer {

--- a/unused/unused.go
+++ b/unused/unused.go
@@ -137,7 +137,7 @@ var Debug io.Writer
 
 - (11.1) anonymous struct types use all their fields. we cannot
   deduplicate struct types, as that leads to order-dependent
-  reportings. we can't not deduplicate struct types while still
+  reports. we can't not deduplicate struct types while still
   tracking fields, because then each instance of the unnamed type in
   the data flow chain will get its own fields, causing false
   positives. Thus, we only accurately track fields of named struct


### PR DESCRIPTION
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/go-tools/commit/4e8a09d73f5936c6a32c9b25504e0dfb92fedb1b#commitcomment-50570388

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/go-tools/commit/1203a60a51d81065f393707fa453023c7a3c813a

Note: this PR does not include the action. If you're interested in running a spell check on every PR and push, that can be offered separately.