### PR TITLE
SA1012: Update doc

### DIFF
--- a/staticcheck/doc.go
+++ b/staticcheck/doc.go
@@ -149,7 +149,7 @@ return all results, specify a negative number.`,
 	},
 
 	"SA1012": {
-		Title:    "A nil `context.Context` is being passed to a function, consider using `context.TODO` instead",
+		Title:    "`nil` is being passed to a function expecting a `context.Context`, consider using `context.TODO` instead",
 		Since:    "2017.1",
 		Severity: lint.SeverityWarning,
 	},


### PR DESCRIPTION
Update description of SA1012 to make it clear it only handles `nil` and not variables with the value `nil`.

Fixes #1084