### PR TITLE
SA1027: add riscv and riscv64 support to test file

### DIFF
--- a/staticcheck/testdata/src/CheckAtomicAlignment/atomic32.go
+++ b/staticcheck/testdata/src/CheckAtomicAlignment/atomic32.go
@@ -1,4 +1,4 @@
-// +build 386 arm armbe mips mipsle ppc s390 sparc
+// +build 386 arm armbe mips mipsle ppc s390 sparc riscv
 
 package pkg
 

--- a/staticcheck/testdata/src/CheckAtomicAlignment/atomic64.go
+++ b/staticcheck/testdata/src/CheckAtomicAlignment/atomic64.go
@@ -1,4 +1,4 @@
-// +build amd64 amd64p32 arm64 ppc64 ppc64le mips64 mips64le mips64p32 mips64p32le sparc64
+// +build amd64 amd64p32 arm64 ppc64 ppc64le mips64 mips64le mips64p32 mips64p32le sparc64 riscv64
 
 package pkg
 


### PR DESCRIPTION
`go test ./...` is failing on `riscv64`. (probably because of missing test file?) Adding `riscv64` to `+build` line will fix.

I have tested this patch on `riscv64` but not on `riscv`. I think this will work on `riscv`.