### PR TITLE
made stylish output a bit more stylish

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e
 	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654
 	golang.org/x/tools v0.1.8
+	mpldr.codes/ansi v1.5.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -30,3 +30,5 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+mpldr.codes/ansi v1.5.0 h1:jAAtDMwU/DC7OPxmrVFpmM3RrSQDcMeLhuk6BuEoWZc=
+mpldr.codes/ansi v1.5.0/go.mod h1:SYuKX0r6nxvySxMxzQX9frQaKLjEqKapjjg17euonMc=

--- a/lintcmd/format.go
+++ b/lintcmd/format.go
@@ -10,6 +10,7 @@ import (
 	"text/tabwriter"
 
 	"honnef.co/go/tools/analysis/lint"
+	"mpldr.codes/ansi"
 )
 
 func shortPath(path string) string {
@@ -156,6 +157,16 @@ func (o *stylishFormatter) Stats(total, errors, warnings, ignored int) {
 		o.tw.Flush()
 		fmt.Fprintln(o.W)
 	}
-	fmt.Fprintf(o.W, " ✖ %d problems (%d errors, %d warnings, %d ignored)\n",
-		total, errors, warnings, ignored)
+
+	icon := ansi.Green("✔")
+	if warnings != 0 {
+		icon = ansi.Yellow(ansi.Bold("!"))
+	}
+
+	if errors != 0 {
+		icon = ansi.Red("✘")
+	}
+
+	fmt.Fprintf(o.W, " %s %d problems (%d errors, %d warnings, %d ignored)\n",
+		icon, total, errors, warnings, ignored)
 }

--- a/lintcmd/format.go
+++ b/lintcmd/format.go
@@ -125,6 +125,8 @@ func (o jsonFormatter) Format(_ []*lint.Analyzer, ps []diagnostic) {
 type stylishFormatter struct {
 	W io.Writer
 
+	failon map[string]bool
+
 	prevFile string
 	tw       *tabwriter.Writer
 }
@@ -145,7 +147,13 @@ func (o *stylishFormatter) Format(_ []*lint.Analyzer, ps []diagnostic) {
 			o.prevFile = pos.Filename
 			o.tw = tabwriter.NewWriter(o.W, 0, 4, 2, ' ', 0)
 		}
-		fmt.Fprintf(o.tw, "  (%d, %d)\t%s\t%s\n", pos.Line, pos.Column, p.Category, p.Message)
+
+		codeFormatter := func(s ...interface{}) string { return ansi.Red(ansi.Bold(s...)) }
+		if !o.failon[p.Category] {
+			codeFormatter = ansi.Yellow
+		}
+
+		fmt.Fprintf(o.tw, "  (%d, %d)\t%s\t%s\n", pos.Line, pos.Column, codeFormatter(p.Category), p.Message)
 		for _, r := range p.Related {
 			fmt.Fprintf(o.tw, "    (%d, %d)\t\t  %s\n", r.Position.Line, r.Position.Column, r.Message)
 		}


### PR DESCRIPTION
This Patchset changes the stylish formatter in the following ways:

- Icon displayed in the summary changes based on results
    - a checkmark if there are no issues (except ignored issues, but I they should not count IMO since they were explicitly ignored)
    - an exclamation mark if there are warnings
    - a cross if there were errors found
        - I didn't use the existing cross, as it would clash visually with the checkmark, and didn't use Emojis because not every system has an Emoji font installed
- Icon is red/yellow/green depending on status
- Categories are coloured based on their severity
    - It was always somewhat hard to parse the list without colour as an optical hint to find the most severe issues