### PR TITLE
Do not report duplicate '-' name when `xml:"-"`

### DIFF
--- a/staticcheck/fakexml/typeinfo.go
+++ b/staticcheck/fakexml/typeinfo.go
@@ -204,6 +204,11 @@ func StructFieldInfo(f fakereflect.StructField) (*fieldInfo, error) {
 		return finfo, nil
 	}
 
+	if tag == "-" {
+		// - a field with tag "-" is omitted.
+		return finfo, nil
+	}
+
 	if tag == "" {
 		// If the name part of the tag is completely empty, get
 		// default from XMLName of underlying struct if feasible,


### PR DESCRIPTION
Addressing false positive reports like:

   Error: pkg/xsd/attribute.go:18:28: SA5008: invalid XML tag: name "-" conflicts with name "attribute" in *github.com/gocomply/xsd2go/pkg/xsd.Attribute.XMLName (staticcheck)
  	refAttr        *Attribute `xml:"-"`

Relevant excerpt from "encoding/xml" documentation:

    - the XMLName field, described above, is omitted.
    - a field with tag "-" is omitted.

See more at https://pkg.go.dev/encoding/xml#Marshal