### PR TITLE
Website: update docsy theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /dist/20??.?.?/
 /dist/20??.?/
 /internal/cmd/irdump/irdump
+/website/.hugo_build.lock
 /website/public
 /website/resources
 /website/assets/img/sponsors

--- a/website/i18n/en.toml
+++ b/website/i18n/en.toml
@@ -1,3 +1,0 @@
-# Fix a typo in Docsy (although we don't currently use the print support)
-[print_printable_section]
-other = "This is the multi-page printable view of this section."


### PR DESCRIPTION
The website uses the [docsy](https://docsy.dev) theme. This PR converts this theme from git submodule to hugo module.
It also brings the theme to latest released version [v0,.2.0](https://github.com/google/docsy/releases/tag/v0.2.0).