### PR TITLE
SA9001: fix false positive in presense of control flow statement

### DIFF
--- a/staticcheck/lint.go
+++ b/staticcheck/lint.go
@@ -1144,17 +1144,31 @@ func CheckDubiousDeferInChannelRangeLoop(pass *analysis.Pass) (interface{}, erro
 		if !ok {
 			return
 		}
+
+		stmts := []*ast.DeferStmt{}
+		exits := false
 		fn2 := func(node ast.Node) bool {
 			switch stmt := node.(type) {
 			case *ast.DeferStmt:
-				report.Report(pass, stmt, "defers in this range loop won't run unless the channel gets closed")
+				stmts = append(stmts, stmt)
 			case *ast.FuncLit:
 				// Don't look into function bodies
 				return false
+			case *ast.ReturnStmt:
+				exits = true
+			case *ast.BranchStmt:
+				exits = node.(*ast.BranchStmt).Tok == token.BREAK
 			}
 			return true
 		}
 		ast.Inspect(loop.Body, fn2)
+
+		if exits {
+			return
+		}
+		for _, stmt := range stmts {
+			report.Report(pass, stmt, "defers in this range loop won't run unless the channel gets closed")
+		}
 	}
 	code.Preorder(pass, fn, (*ast.RangeStmt)(nil))
 	return nil, nil

--- a/staticcheck/testdata/src/CheckDubiousDeferInChannelRangeLoop/CheckDubiousDeferInChannelRangeLoop.go
+++ b/staticcheck/testdata/src/CheckDubiousDeferInChannelRangeLoop/CheckDubiousDeferInChannelRangeLoop.go
@@ -6,3 +6,16 @@ func fn() {
 		defer println() //@ diag(`defers in this range loop`)
 	}
 }
+
+func fn2() {
+	var ch chan int
+	for range ch {
+		defer println()
+		break
+	}
+
+	for range ch {
+		defer println()
+		return
+	}
+}


### PR DESCRIPTION
As noted in the Issue: https://github.com/dominikh/go-tools/issues/488,
let's check if there is either a `return` statement or a `break` control
flow when looping over channels. This would reduce false positives.

Add a test for the same as noted in the issue!