### PR TITLE
analysis/facts: fix `fact_deprecated` analyzer

### DIFF
--- a/analysis/facts/deprecated/deprecated.go
+++ b/analysis/facts/deprecated/deprecated.go
@@ -48,6 +48,7 @@ func deprecated(pass *analysis.Pass) (interface{}, error) {
 		}
 		return ""
 	}
+
 	doDocs := func(names []*ast.Ident, docs []*ast.CommentGroup) {
 		alt := extractDeprecatedMessage(docs)
 		if alt == "" {
@@ -86,7 +87,15 @@ func deprecated(pass *analysis.Pass) (interface{}, error) {
 				switch node.Tok {
 				case token.TYPE, token.CONST, token.VAR:
 					docs = append(docs, node.Doc)
-					return true
+					for i := range node.Specs {
+						switch n := node.Specs[i].(type) {
+						case *ast.ValueSpec:
+							names = append(names, n.Names...)
+						case *ast.TypeSpec:
+							names = append(names, n.Name)
+						}
+					}
+					ret = true
 				default:
 					return false
 				}

--- a/analysis/facts/deprecated/testdata/src/Deprecated/Deprecated.go
+++ b/analysis/facts/deprecated/testdata/src/Deprecated/Deprecated.go
@@ -11,3 +11,37 @@ func fn2() { // want fn2:`Deprecated: Don't use this\.`
 // Here is how you might use it instead.
 func fn3() { // want fn3:`Deprecated: Don't use this\.`
 }
+
+// Handle cases like:
+//
+// Taken from "os" package:
+//
+// ```
+// // Deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.
+// const (
+// 	SEEK_SET int = 0 // seek relative to the origin of the file
+// 	SEEK_CUR int = 1 // seek relative to the current offset
+// 	SEEK_END int = 2 // seek relative to the end
+// )
+// ```
+//
+// Here all three consts i.e., os.SEEK_SET, os.SEEK_CUR and os.SEEK_END are
+// deprecated and not just os.SEEK_SET.
+
+// Deprecated: Don't use this.
+var (
+	SEEK_A = 0 // want SEEK_A:`Deprecated: Don't use this\.`
+	SEEK_B = 1 // want SEEK_B:`Deprecated: Don't use this\.`
+	SEEK_C = 2 // want SEEK_C:`Deprecated: Don't use this\.`
+)
+
+// Deprecated: Don't use this.
+type (
+	pair struct{ x, y int }    // want pair:`Deprecated: Don't use this\.`
+	cube struct{ x, y, z int } // want cube:`Deprecated: Don't use this\.`
+)
+
+// Deprecated: Don't use this.
+var SEEK_D = 3 // want SEEK_D:`Deprecated: Don't use this\.`
+var SEEK_E = 4
+var SEEK_F = 5

--- a/analysis/facts/deprecated/testdata/src/Deprecated/Deprecated.go
+++ b/analysis/facts/deprecated/testdata/src/Deprecated/Deprecated.go
@@ -41,6 +41,12 @@ type (
 	cube struct{ x, y, z int } // want cube:`Deprecated: Don't use this\.`
 )
 
+const (
+	SE_1 rune = iota
+	SE_2      // Deprecated: Don't use this. // want SE_2:`Deprecated: Don't use this\.`
+	SE_3
+)
+
 // Deprecated: Don't use this.
 var SEEK_D = 3 // want SEEK_D:`Deprecated: Don't use this\.`
 var SEEK_E = 4

--- a/staticcheck/testdata/src/CheckDeprecated_go18/CheckDeprecated.go
+++ b/staticcheck/testdata/src/CheckDeprecated_go18/CheckDeprecated.go
@@ -17,6 +17,8 @@ func fn1(err error) {
 	_ = rp.Cancel                       //@ diag(re`deprecated since Go 1\.7:.+If a Request's Cancel field and context are both`)
 	_ = syscall.StringByteSlice("")     //@ diag(`Use ByteSliceFromString instead`)
 	_ = os.SEEK_SET                     //@ diag(`Use io.SeekStart, io.SeekCurrent, and io.SeekEnd`)
+	_ = os.SEEK_CUR                     //@ diag(`Use io.SeekStart, io.SeekCurrent, and io.SeekEnd`)
+	_ = os.SEEK_END                     //@ diag(`Use io.SeekStart, io.SeekCurrent, and io.SeekEnd`)
 	if err == http.ErrWriteAfterFlush { //@ diag(`ErrWriteAfterFlush is no longer`)
 		println()
 	}


### PR DESCRIPTION
`fact_deprecated` analyzer is now able to correctly detect all the deprecated const and type. I have also updated `SA1019`'s testdata in order to show the effect on SA1019 after fixing the `fact_deprecated`.

Fixes https://github.com/dominikh/go-tools/issues/1313

Also, it doesn't detect inline comments in some cases, fixed that as well.

Signed-off-by: subham sarkar <sarkar.subhams2@gmail.com>