### PR TITLE
go-staticcheck is the package Debian users want

### DIFF
--- a/website/content/docs/getting-started.md
+++ b/website/content/docs/getting-started.md
@@ -32,7 +32,7 @@ Arch Linux
 : [staticcheck](https://archlinux.org/packages/community/x86_64/staticcheck/)
 
 Debian
-: [golang-honnef-go-tools-dev](https://packages.debian.org/sid/golang-honnef-go-tools-dev)
+: [go-staticcheck](https://packages.debian.org/go-staticcheck)
 
 Fedora
 : [golang-honnef-tools](https://fedora.pkgs.org/33/fedora-x86_64/golang-honnef-tools-2020.1.5-2.fc33.x86_64.rpm.html)


### PR DESCRIPTION
I was poking around at staticcheck today on Debian, and after some initial confusion, determined that the correct package users need to install is `go-staticcheck`. This PR corrects the documentation.