### PR TITLE
Preferring early loop exits to reduce indentation

### DIFF
--- a/stylecheck/analysis.go
+++ b/stylecheck/analysis.go
@@ -81,4 +81,9 @@ var Analyzers = lint.InitializeAnalyzers(Docs, map[string]*analysis.Analyzer{
 		Requires: []*analysis.Analyzer{generated.Analyzer, inspect.Analyzer},
 	},
 	"ST1023": sharedcheck.RedundantTypeInDeclarationChecker("should", false),
+	"ST1024": {
+		Run:      CheckEarlyLoopReturns,
+		Requires: []*analysis.Analyzer{generated.Analyzer, inspect.Analyzer},
+	},
+
 })

--- a/stylecheck/doc.go
+++ b/stylecheck/doc.go
@@ -259,4 +259,38 @@ information on how to write good documentation.`,
 		NonDefault: true,
 		MergeIf:    lint.MergeIfAll,
 	},
+
+	"ST1024": {
+		Title: 		"Prefer Early loop returns",
+		Since:		"2022.12",
+		Text:  `if a for loop has only one if condition in it and
+it is longer than 10 statements then its better to have a simple
+if with a break early on instead.
+
+Instead of 
+    for {
+	if n > 5 {
+	    ...
+	    ...
+	    ...
+	    (more than 10 lines)
+	}
+    }
+use
+    for {
+	if n <= 5 {
+	    break
+	}
+	...
+	...
+	...
+	(more than 10 lines)
+	}
+    }
+
+This reduces the indent which makes it more readable.`,
+		NonDefault:	true,
+		MergeIf: lint.MergeIfAll,
+	},
+
 })

--- a/stylecheck/lint_test.go
+++ b/stylecheck/lint_test.go
@@ -26,6 +26,7 @@ func TestAll(t *testing.T) {
 		"ST1021": {{Dir: "CheckExportedTypeDocs"}},
 		"ST1022": {{Dir: "CheckExportedVarDocs"}},
 		"ST1023": {{Dir: "CheckRedundantTypeInDeclaration"}, {Dir: "CheckRedundantTypeInDeclaration_syscall"}},
+		"ST1024": {{Dir: "CheckEarlyLoopReturns"}},
 	}
 
 	testutil.Run(t, Analyzers, checks)

--- a/stylecheck/testdata/src/CheckEarlyLoopReturns/CheckEarlyLoopReturns.go
+++ b/stylecheck/testdata/src/CheckEarlyLoopReturns/CheckEarlyLoopReturns.go
@@ -1,0 +1,89 @@
+package pkg
+
+import (
+	"math/rand"
+	"fmt"
+)
+
+func fn() {
+	n := rand.Intn(10)
+	for { //@ diag(`for loop with a single if statement in the body is a candidate for early return`)
+		if n > 5 {
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+		}
+	}
+
+	// Comments should not affect the warning.
+	for { //@ diag(`for loop with a single if statement in the body is a candidate for early return`)
+		// Just an uninteresting comment.
+		if n > 5 {
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+		}
+	}
+
+	// The if statement has < 10 lines so no warning should be shown.
+	for {
+		if n > 5 {
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+		}
+	}
+	for {
+		// This if condition should NOT be caught because there is another statement after
+		// the if condition within the for loop.
+		if n > 5 {
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+		}
+		fmt.Println("Extra line")
+	}
+	for {
+		fmt.Println("Extra line")
+		// This if condition should NOT be caught because there is another statement before
+		// the if condition within the for loop.
+		if n > 5 {
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+			fmt.Println("1")
+		}
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/dominikh/go-tools/issues/1334

The check, 
1. looks for for-loops with single children. 
2. It further checks if the child is an *if* condition. 
3. Finally it checks that the *if* condition has more than 10 children.