### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/internal/renameio/renameio_test.go
+++ b/internal/renameio/renameio_test.go
@@ -11,7 +11,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"math/rand"
-	"os"
 	"path/filepath"
 	"runtime"
 	"sync"
@@ -24,11 +23,7 @@ import (
 )
 
 func TestConcurrentReadsAndWrites(t *testing.T) {
-	dir, err := os.MkdirTemp("", "renameio")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	path := filepath.Join(dir, "blob.bin")
 
 	const chunkWords = 8 << 10

--- a/internal/renameio/umask_test.go
+++ b/internal/renameio/umask_test.go
@@ -15,18 +15,14 @@ import (
 )
 
 func TestWriteFileModeAppliesUmask(t *testing.T) {
-	dir, err := os.MkdirTemp("", "renameio")
-	if err != nil {
-		t.Fatalf("Failed to create temporary directory: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	const mode = 0644
 	const umask = 0007
 	defer syscall.Umask(syscall.Umask(umask))
 
 	file := filepath.Join(dir, "testWrite")
-	err = WriteFile(file, []byte("go-build"), mode)
+	err := WriteFile(file, []byte("go-build"), mode)
 	if err != nil {
 		t.Fatalf("Failed to write file: %v", err)
 	}

--- a/lintcmd/cache/cache_test.go
+++ b/lintcmd/cache/cache_test.go
@@ -19,12 +19,8 @@ func init() {
 }
 
 func TestBasic(t *testing.T) {
-	dir, err := os.MkdirTemp("", "cachetest-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-	_, err = Open(filepath.Join(dir, "notexist"))
+	dir := t.TempDir()
+	_, err := Open(filepath.Join(dir, "notexist"))
 	if err == nil {
 		t.Fatal(`Open("tmp/notexist") succeeded, want failure`)
 	}
@@ -64,11 +60,7 @@ func TestBasic(t *testing.T) {
 }
 
 func TestGrowth(t *testing.T) {
-	dir, err := os.MkdirTemp("", "cachetest-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	c, err := Open(dir)
 	if err != nil {
@@ -117,11 +109,7 @@ func TestVerifyPanic(t *testing.T) {
 		t.Fatal("initEnv did not set verify")
 	}
 
-	dir, err := os.MkdirTemp("", "cachetest-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	c, err := Open(dir)
 	if err != nil {
@@ -150,11 +138,7 @@ func dummyID(x int) [HashSize]byte {
 }
 
 func TestCacheTrim(t *testing.T) {
-	dir, err := os.MkdirTemp("", "cachetest-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	c, err := Open(dir)
 	if err != nil {


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	if err != nil {
		t.Fatal(err)
	}
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```