### PR TITLE
go/ir,unused: fix comment typos

### DIFF
--- a/go/ir/builder.go
+++ b/go/ir/builder.go
@@ -311,7 +311,7 @@ func (b *builder) builtin(fn *Function, obj *types.Builtin, args []ast.Expr, typ
 //
 // Operations forming potentially escaping pointers include:
 // - &x, including when implicit in method call or composite literals.
-// - a[:] iff a is an array (not *array)
+// - a[:] if a is an array (not *array)
 // - references to variables in lexically enclosing functions.
 func (b *builder) addr(fn *Function, e ast.Expr, escaping bool) (RET lvalue) {
 	switch e := e.(type) {
@@ -853,7 +853,7 @@ func (b *builder) stmtList(fn *Function, list []ast.Stmt) {
 // returns the effective receiver after applying the implicit field
 // selections of sel.
 //
-// wantAddr requests that the result is an an address.  If
+// wantAddr requests that the result is an address. If
 // !sel.Indirect(), this may require that e be built in addr() mode; it
 // must thus be addressable.
 //

--- a/go/ir/emit.go
+++ b/go/ir/emit.go
@@ -119,7 +119,7 @@ func emitArith(f *Function, op token.Token, x, y Value, t types.Type, source ast
 }
 
 // emitCompare emits to f code compute the boolean result of
-// comparison comparison 'x op y'.
+// comparison 'x op y'.
 func emitCompare(f *Function, op token.Token, x, y Value, source ast.Node) Value {
 	xt := x.Type().Underlying()
 	yt := y.Type().Underlying()
@@ -430,7 +430,7 @@ func emitImplicitSelections(f *Function, v Value, indices []int, source ast.Node
 			}
 			instr.setType(types.NewPointer(fld.Type()))
 			v = f.emit(instr, source)
-			// Load the field's value iff indirectly embedded.
+			// Load the field's value if indirectly embedded.
 			if isPointer(fld.Type()) {
 				v = emitLoad(f, v, source)
 			}
@@ -466,7 +466,7 @@ func emitFieldSelection(f *Function, v Value, index int, wantAddr bool, id *ast.
 		instr.setSource(id)
 		instr.setType(types.NewPointer(fld.Type()))
 		v = f.emit(instr, id)
-		// Load the field's value iff we don't want its address.
+		// Load the field's value if we don't want its address.
 		if !wantAddr {
 			v = emitLoad(f, v, id)
 		}

--- a/go/ir/source_test.go
+++ b/go/ir/source_test.go
@@ -54,7 +54,7 @@ func TestObjValueLookup(t *testing.T) {
 
 	// Each note of the form @ir(x, "BinOp") in testdata/objlookup.go
 	// specifies an expectation that an object named x declared on the
-	// same line is associated with an an ir.Value of type *ir.BinOp.
+	// same line is associated with an ir.Value of type *ir.BinOp.
 	notes, err := expect.ExtractGo(conf.Fset, f)
 	if err != nil {
 		t.Fatal(err)

--- a/go/ir/ssa.go
+++ b/go/ir/ssa.go
@@ -156,7 +156,7 @@ type Value interface {
 	//
 	// Referrers is currently only defined if Parent()!=nil,
 	// i.e. for the function-local values FreeVar, Parameter,
-	// Functions (iff anonymous) and all value-defining instructions.
+	// Functions (if anonymous) and all value-defining instructions.
 	// It returns nil for named Functions, Builtin and Global.
 	//
 	// Instruction.Operands contains the inverse of this relation.
@@ -366,7 +366,7 @@ type Function struct {
 	Blocks    []*BasicBlock // basic blocks of the function; nil => external
 	Exit      *BasicBlock   // The function's exit block
 	AnonFuncs []*Function   // anonymous functions directly beneath this one
-	referrers []Instruction // referring instructions (iff Parent() != nil)
+	referrers []Instruction // referring instructions (if Parent() != nil)
 	NoReturn  NoReturn      // Calling this function will always terminate control flow.
 
 	*functionBody
@@ -1203,7 +1203,7 @@ type SelectState struct {
 // index index.
 //
 // The second component of the triple, recvOk, is a boolean whose value
-// is true iff the selected operation was a receive and the receive
+// is true if the selected operation was a receive and the receive
 // successfully yielded a value.
 //
 // Pos() returns the ast.SelectStmt.Select.
@@ -1279,7 +1279,7 @@ type Next struct {
 // dynamic type of the interface is assignable to it, and if so, the
 // result of the conversion is a copy of the interface value X.
 // If AssertedType is a superinterface of X.Type(), the operation will
-// fail iff the operand is nil.  (Contrast with ChangeInterface, which
+// fail if the operand is nil.  (Contrast with ChangeInterface, which
 // performs no nil-check.)
 //
 // Type() reflects the actual type of the result, possibly a

--- a/go/ir/util.go
+++ b/go/ir/util.go
@@ -22,7 +22,7 @@ import (
 
 func unparen(e ast.Expr) ast.Expr { return astutil.Unparen(e) }
 
-// isBlankIdent returns true iff e is an Ident with name "_".
+// isBlankIdent returns true if e is an Ident with name "_".
 // They have no associated types.Object, and thus no type.
 func isBlankIdent(e ast.Expr) bool {
 	id, ok := e.(*ast.Ident)

--- a/unused/unused.go
+++ b/unused/unused.go
@@ -54,7 +54,7 @@ This overview is true when using the default options. Different options may chan
   - (1.4) exported constants
   - (1.5) init functions
   - (1.6) functions exported to cgo
-  - (1.7) the main function iff in the main package
+  - (1.7) the main function if in the main package
   - (1.8) symbols linked via go:linkname
   - (1.9) objects in generated files
 
@@ -1164,7 +1164,7 @@ func (g *graph) decl(decl ast.Decl, by types.Object) {
 			// (1.5) packages use init functions
 			g.use(obj, nil)
 		} else if decl.Name.Name == "main" && g.pkg.Name() == "main" {
-			// (1.7) packages use the main function iff in the main package
+			// (1.7) packages use the main function if in the main package
 			g.use(obj, nil)
 		} else if g.pkg.Path() == "runtime" && runtimeFuncs[decl.Name.Name] {
 			// (9.8) runtime functions that may be called from user code via the compiler


### PR DESCRIPTION
Change Go comments:
- rename `iff` -> `if`;
- remove duplicated words.