### PR TITLE
ST1018: don't flag emojis containing U+FE0F,U+200D

### DIFF
--- a/stylecheck/lint.go
+++ b/stylecheck/lint.go
@@ -732,7 +732,7 @@ func CheckInvisibleCharacters(pass *analysis.Pass) (interface{}, error) {
 			if unicode.Is(unicode.Cf, r) {
 				// Don't flag joined emojis. These are multiple emojis joined with ZWJ, which some platform render as single composite emojis.
 				// For the purpose of this check, we consider all symbols, including all symbol modifiers, emoji.
-				if r != zwj || (r == zwj && !unicode.Is(unicode.S, prev)) {
+				if r != zwj || (prev != '\ufe0f' && !unicode.Is(unicode.S, prev)) {
 					invalids = append(invalids, invalid{r, off})
 					hasFormat = true
 				}


### PR DESCRIPTION
Background: <https://github.com/dominikh/go-tools/issues/1113>

`staticcheck/v0.4.6` reports

```
string literal contains the Unicode format character U+200D, consider using the '\u200d' escape sequence instead (ST1018)
```

for emojis containing the sequence `U+FE0F,U+200D`[^1]. The reason is that `U+FE0F` is not in `unicode.S`. This PR adds a special check for it.

<details>
  <summary>Example Program</summary>

```go
package main

import (
	"fmt"
	"unicode"
)

func main() {
	// https://en.wikipedia.org/wiki/Zero-width_joiner#Examples
	emojis := [...]string{
		"👨‍👩‍👦",
		"🏳️‍🌈",
	}

	for _, emoji := range emojis {
		fmt.Println(emoji)
		for _, e := range emoji {
			fmt.Printf("%+12q unicode.S: %v\n", e, unicode.Is(unicode.S, e))
		}
	}
}
```

</details>

[^1]: There are lots of them, see <https://www.unicode.org/Public/emoji/15.1/emoji-zwj-sequences.txt>
