### PR TITLE
Add a check for ignored errors in function calls

### DIFF
--- a/staticcheck/analysis.go
+++ b/staticcheck/analysis.go
@@ -89,6 +89,10 @@ var Analyzers = lint.InitializeAnalyzers(Docs, map[string]*analysis.Analyzer{
 	"SA1029": makeCallCheckerAnalyzer(checkWithValueKeyRules),
 	"SA1030": makeCallCheckerAnalyzer(checkStrconvRules),
 	"SA1031": makeCallCheckerAnalyzer(checkEncodeRules),
+	"SA1032": {
+		Run:      CheckIgnoredError,
+		Requires: []*analysis.Analyzer{inspect.Analyzer},
+	},
 
 	"SA2000": {
 		Run:      CheckWaitgroupAdd,

--- a/staticcheck/doc.go
+++ b/staticcheck/doc.go
@@ -343,6 +343,14 @@ writes more than one byte per \'src\' byte.`,
 		MergeIf:  lint.MergeIfAny,
 	},
 
+	"SA1032": {
+		Title:    `Find ignored errors`,
+		Text:     `Finds function calls, where the function returns an error but the call site ignored the error.`,
+		Since:    "Unreleased",
+		Severity: lint.SeverityWarning,
+		MergeIf:  lint.MergeIfAny,
+	},
+
 	"SA2000": {
 		Title:    `\'sync.WaitGroup.Add\' called inside the goroutine, leading to a race condition`,
 		Since:    "2017.1",

--- a/staticcheck/lint_test.go
+++ b/staticcheck/lint_test.go
@@ -52,6 +52,9 @@ func TestAll(t *testing.T) {
 			{Dir: "example.com/CheckEncodingBase64"},
 			{Dir: "example.com/CheckEncodingHex"},
 		},
+		"SA1032": {
+			{Dir: "example.com/CheckIgnoredError"},
+		},
 		"SA2000": {{Dir: "example.com/CheckWaitgroupAdd"}},
 		"SA2001": {{Dir: "example.com/CheckEmptyCriticalSection"}},
 		"SA2002": {{Dir: "example.com/CheckConcurrentTesting"}},

--- a/staticcheck/testdata/src/example.com/CheckIgnoredError/ignored_errors.go
+++ b/staticcheck/testdata/src/example.com/CheckIgnoredError/ignored_errors.go
@@ -1,0 +1,29 @@
+package pkg
+
+import (
+	"fmt"
+)
+
+func returnsError(n int) error {
+	fmt.Printf("dummy side effect\n")
+	if n < 0 {
+		return fmt.Errorf("n is negative")
+	}
+	return nil
+}
+
+func noError(n int) (error, int) {
+	fmt.Printf("dummy side effect\n")
+	return nil, n * 2
+}
+
+func Test() {
+	returnsError(1)     //@ diag(`The error returned from calling 'returnsError' is ignored. Do not ignore returned errors as this might hide bugs.`)
+	_ = returnsError(2) // explicitly ignoring the error is okay
+	noError(3)          // if the error is not the last returned value, then there is no warning (already covered by ST1008)
+}
+
+func InIf() {
+	if returnsError(4); true { //@ diag(`The error returned from calling 'returnsError' is ignored. Do not ignore returned errors as this might hide bugs.`)
+	}
+}


### PR DESCRIPTION
Hi there. This is my first PR here, and I did not find a contributing guide. So please guide me through what I need to do :) 

This PR adds a check for unhandled errors. This check is one of the cases where Intellij Goland gives a warning, but staticcheck does not.

The rule here is simple. You get a warning if:

- You have a `CallExpr` as direct parent of an `ExprStmt` (meaning the result is not used)
- And: The called function has an `error` as the last returned type