### PR TITLE
Reword interface{} as any

### DIFF
--- a/add-check.go
+++ b/add-check.go
@@ -43,7 +43,7 @@ var SCAnalyzer = lint.InitializeAnalyzer(&lint.Analyzer{
 
 var Analyzer = SCAnalyzer.Analyzer
 
-func run(pass *analysis.Pass) (interface{}, error) {
+func run(pass *analysis.Pass) (any, error) {
 	return nil, nil
 }
 `


### PR DESCRIPTION
Should be fine since the module requires Go 1.21