### PR TITLE
Add Analyzer alias to sa9003

### DIFF
--- a/staticcheck/sa9003/sa9003.go
+++ b/staticcheck/sa9003/sa9003.go
@@ -26,6 +26,8 @@ var SCAnalyzer = lint.InitializeAnalyzer(&lint.Analyzer{
 	},
 })
 
+var Analyzer = SCAnalyzer.Analyzer
+
 func run(pass *analysis.Pass) (interface{}, error) {
 	for _, fn := range pass.ResultOf[buildir.Analyzer].(*buildir.IR).SrcFuncs {
 		if fn.Source() == nil {


### PR DESCRIPTION
sa9003 was missing a public `Analyzer` which would conform with the other static checks and work well with tools that expect the package to expose `Analyzer` alias.