### PR TITLE
Update staticcheck x GitHub action guide

### DIFF
--- a/website/content/docs/running-staticcheck/ci/github-actions/index.md
+++ b/website/content/docs/running-staticcheck/ci/github-actions/index.md
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dominikh/staticcheck-action@v1.3.0
         with:
-          version: "2022.1.1"
+          version: "2023.1.6"
 ```
 
 A more advanced example that runs tests, go vet and Staticcheck on multiple OSs and Go versions looks like this:

--- a/website/content/docs/running-staticcheck/ci/github-actions/index.md
+++ b/website/content/docs/running-staticcheck/ci/github-actions/index.md
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macOS-latest"]
-        go: ["1.17.x", "1.18.x"]
+        go: ["1.21.x", "1.22.x"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/website/content/docs/running-staticcheck/ci/github-actions/index.md
+++ b/website/content/docs/running-staticcheck/ci/github-actions/index.md
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dominikh/staticcheck-action@v1.3.0
         with:
-          version: "2023.1.6"
+          version: "2023.1.7"
 ```
 
 A more advanced example that runs tests, go vet and Staticcheck on multiple OSs and Go versions looks like this:
@@ -51,7 +51,7 @@ jobs:
       - run: "go vet ./..."
       - uses: dominikh/staticcheck-action@v1.3.0
         with:
-          version: "2023.1.6"
+          version: "2023.1.7"
           install-go: false
           cache-key: ${{ matrix.go }}
 ```

--- a/website/content/docs/running-staticcheck/ci/github-actions/index.md
+++ b/website/content/docs/running-staticcheck/ci/github-actions/index.md
@@ -18,15 +18,13 @@ on: ["push", "pull_request"]
 
 jobs:
   ci:
-	name: "Run CI"
-	runs-on: ubuntu-latest
-	steps:
-	- uses: actions/checkout@v1
-	  with:
-		fetch-depth: 1
-	- uses: dominikh/staticcheck-action@v1.2.0
-	  with:
-		version: "2022.1.1"
+    name: "Run CI"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dominikh/staticcheck-action@v1.3.0
+        with:
+          version: "2022.1.1"
 ```
 
 A more advanced example that runs tests, go vet and Staticcheck on multiple OSs and Go versions looks like this:
@@ -37,27 +35,25 @@ on: ["push", "pull_request"]
 
 jobs:
   ci:
-	name: "Run CI"
-	strategy:
-	  fail-fast: false
-	  matrix:
-		os: ["windows-latest", "ubuntu-latest", "macOS-latest"]
-		go: ["1.16.x", "1.17.x"]
-	runs-on: ${{ matrix.os }}
-	steps:
-	- uses: actions/checkout@v1
-	  with:
-		fetch-depth: 1
-	- uses: WillAbides/setup-go-faster@v1.7.0
-	  with:
-		go-version: ${{ matrix.go }}
-	- run: "go test ./..."
-	- run: "go vet ./..."
-	- uses: dominikh/staticcheck-action@v1.2.0
-	  with:
-		version: "2022.1.1"
-		install-go: false
-		cache-key: ${{ matrix.go }}
+    name: "Run CI"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["windows-latest", "ubuntu-latest", "macOS-latest"]
+        go: ["1.17.x", "1.18.x"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: WillAbides/setup-go-faster@v1.13.0
+        with:
+          go-version: ${{ matrix.go }}
+      - run: "go test ./..."
+      - run: "go vet ./..."
+      - uses: dominikh/staticcheck-action@v1.3.0
+        with:
+          version: "2022.1.1"
+          install-go: false
+          cache-key: ${{ matrix.go }}
 ```
 
 Note that this example could benefit from further improvements, such as caching of Go's build cache.

--- a/website/content/docs/running-staticcheck/ci/github-actions/index.md
+++ b/website/content/docs/running-staticcheck/ci/github-actions/index.md
@@ -51,7 +51,7 @@ jobs:
       - run: "go vet ./..."
       - uses: dominikh/staticcheck-action@v1.3.0
         with:
-          version: "2022.1.1"
+          version: "2023.1.6"
           install-go: false
           cache-key: ${{ matrix.go }}
 ```


### PR DESCRIPTION
Changelogs:

- Use the GitHub `actions/checkout@v4` instead of the old one. also, remove the `fetch-depth` property as the default is already set to `1`.
- Fix the go versions in the example. the go `v1.16.x` is not supported by staticcheck `v2022.1.1`
  - use go `v1.21.x` & `v1.22.x` instead
  - reference: https://github.com/dominikh/go-tools/issues/1251#issuecomment-1096744855
- adjust space/indentation