### PR TITLE
quickfix: avoid panic in CheckDeMorgan

### DIFF
--- a/quickfix/qf1001/qf1001.go
+++ b/quickfix/qf1001/qf1001.go
@@ -40,10 +40,12 @@ func CheckDeMorgan(pass *analysis.Pass) (interface{}, error) {
 		found := false
 		ast.Inspect(expr, func(node ast.Node) bool {
 			if expr, ok := node.(ast.Expr); ok {
-				if basic, ok := pass.TypesInfo.TypeOf(expr).Underlying().(*types.Basic); ok {
-					if (basic.Info() & types.IsFloat) != 0 {
-						found = true
-						return false
+				if typ := pass.TypesInfo.TypeOf(expr); typ != nil {
+					if basic, ok := typ.Underlying().(*types.Basic); ok {
+						if (basic.Info() & types.IsFloat) != 0 {
+							found = true
+							return false
+						}
 					}
 				}
 			}


### PR DESCRIPTION
fix the issue https://github.com/dominikh/go-tools/issues/1484

`pass.TypesInfo.TypeOf(expr)` could return nil in some cases.
In the given example, the type of KeyValueExpr is not found.
Then it causes panic.