### PR TITLE
SA5008: check for missing closing quote

### DIFF
--- a/staticcheck/sa5008/structtag.go
+++ b/staticcheck/sa5008/structtag.go
@@ -3,10 +3,12 @@
 
 package sa5008
 
-import "strconv"
+import (
+	"errors"
+	"strconv"
+)
 
 func parseStructTag(tag string) (map[string][]string, error) {
-	// FIXME(dh): detect missing closing quote
 	out := map[string][]string{}
 
 	for tag != "" {
@@ -43,7 +45,7 @@ func parseStructTag(tag string) (map[string][]string, error) {
 			i++
 		}
 		if i >= len(tag) {
-			break
+			return nil, errors.New("missing closing quote")
 		}
 		qvalue := string(tag[:i+1])
 		tag = tag[i+1:]

--- a/staticcheck/sa5008/testdata/src/example.com/CheckStructTags/CheckStructTags.go
+++ b/staticcheck/sa5008/testdata/src/example.com/CheckStructTags/CheckStructTags.go
@@ -21,6 +21,8 @@ type T1 struct {
 	M complex128 `json:",string"` //@ diag(`the JSON string option`)
 	N int        `json:"some-name"`
 	O int        `json:"some-name,omitzero,omitempty,nocase,inline,unknown,format:'something,with,commas'"`
+	P int        `json:"`          //@ diag(`missing closing quote`)
+	Q int        `json:"some-name` //@ diag(`missing closing quote`)
 }
 
 type T2 struct {


### PR DESCRIPTION
This PR attempts to address handling the missing closing quote case for the struct tag parser.

I could be naive here, but changing the current implementation of the scanner from `break`ing when it's unable to find the closing double quote to returning an error would achieve this. This does the change the behaviour to now ignore partially valid tags (i.e. `` `xml:"complete" json:"missing` `` would no longer result in the `xml:"complete"` being checked), instead it will highlight the missing closing quote violation.

I'm not familiar with the intended `testdata` organization, so I've proposed a test case for this under the `example.com/CheckStructTags`.