### PR TITLE
structlayout: align output

### DIFF
--- a/cmd/structlayout/main.go
+++ b/cmd/structlayout/main.go
@@ -9,6 +9,7 @@ import (
 	"go/types"
 	"log"
 	"os"
+	"text/tabwriter"
 
 	"honnef.co/go/tools/go/gcsizes"
 	"honnef.co/go/tools/lintcmd/version"
@@ -85,9 +86,16 @@ func emitJSON(fields []st.Field) {
 }
 
 func emitText(fields []st.Field) {
-	for _, field := range fields {
-		fmt.Println(field)
+	t := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
+	for _, f := range fields {
+		n := f.Name
+		if f.IsPadding {
+			n = "  padding"
+		}
+		fmt.Fprintf(t, "%s\t%s\t%2d-%d\t(size %2d,\talign %2d)\n",
+			n, f.Type, f.Start, f.End, f.Size, f.Align)
 	}
+	t.Flush()
 }
 func sizes(typ *types.Struct, prefix string, base int64, out []st.Field) []st.Field {
 	s := gcsizes.ForArch(build.Default.GOARCH)


### PR DESCRIPTION
This aligns the output of structlayout. To my eyes at least, this is a lot more readable, including more readable than the structlayout-pretty output.

Before:

	% structlayout bufio Reader
	column.name string: 0-16 (size 16, align 8)
	column.width int: 16-24 (size 8, align 8)
	column.align int: 24-32 (size 8, align 8)
	column.trim bool: 32-33 (size 1, align 1)
	column.quote uint8: 33-34 (size 1, align 1)
	padding: 34-40 (size 6, align 0)
	column.quoteChar [2]string: 40-72 (size 32, align 8)
	column.fill rune: 72-76 (size 4, align 4)
	column.noHeader bool: 76-77 (size 1, align 1)
	padding: 77-80 (size 3, align 0)

	% structlayout zgo.at/uni/v2/unidata Emoji
	Emoji.Codepoints []rune: 0-24 (size 24, align 8)
	Emoji.Name string: 24-40 (size 16, align 8)
	Emoji.group zgo.at/uni/v2/unidata.EmojiGroup: 40-41 (size 1, align 1)
	padding: 41-42 (size 1, align 0)
	Emoji.subgroup zgo.at/uni/v2/unidata.EmojiSubgroup: 42-44 (size 2, align 2)
	padding: 44-48 (size 4, align 0)
	Emoji.CLDR []string: 48-72 (size 24, align 8)
	Emoji.skinTones bool: 72-73 (size 1, align 1)
	padding: 73-80 (size 7, align 0)
	Emoji.gender int: 80-88 (size 8, align 8)

And after:

	% structlayout bufio Reader
	Reader.buf           []byte      0-24  (size 24,  align  8)
	Reader.rd            io.Reader  24-40  (size 16,  align  8)
	Reader.r             int        40-48  (size  8,  align  8)
	Reader.w             int        48-56  (size  8,  align  8)
	Reader.err           error      56-72  (size 16,  align  8)
	Reader.lastByte      int        72-80  (size  8,  align  8)
	Reader.lastRuneSize  int        80-88  (size  8,  align  8)

	% structlayout zgo.at/uni/v2/unidata Emoji
	Emoji.Codepoints  []rune                                0-24  (size 24,  align  8)
	Emoji.Name        string                               24-40  (size 16,  align  8)
	Emoji.group       zgo.at/uni/v2/unidata.EmojiGroup     40-41  (size  1,  align  1)
	  padding                                              41-42  (size  1,  align  0)
	Emoji.subgroup    zgo.at/uni/v2/unidata.EmojiSubgroup  42-44  (size  2,  align  2)
	  padding                                              44-48  (size  4,  align  0)
	Emoji.CLDR        []string                             48-72  (size 24,  align  8)
	Emoji.skinTones   bool                                 72-73  (size  1,  align  1)
	  padding                                              73-80  (size  7,  align  0)
	Emoji.gender      int                                  80-88  (size  8,  align  8)