### PR TITLE
S1017: don't trigger if there's an "else if" branch

### DIFF
--- a/simple/s1017/s1017.go
+++ b/simple/s1017/s1017.go
@@ -73,6 +73,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		return sameNonDynamic(call.Args[knowledge.Arg("len.v")], ident)
 	}
 
+	seen := make(map[ast.Node]struct{})
 	fn := func(node ast.Node) {
 		var pkg string
 		var fun string
@@ -82,6 +83,10 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			return
 		}
 		if ifstmt.Else != nil {
+			seen[ifstmt.Else] = struct{}{}
+			return
+		}
+		if _, ok := seen[ifstmt]; ok {
 			return
 		}
 		if len(ifstmt.Body.List) != 1 {

--- a/simple/s1017/testdata/src/example.com/CheckTrim/trim.go
+++ b/simple/s1017/testdata/src/example.com/CheckTrim/trim.go
@@ -167,6 +167,13 @@ func fn2() {
 	if strings.HasSuffix(s, ".json") {
 		s = s[:len(s)-4] // wrong length
 	}
+
+	// Don't check with else if branch; see #1447
+	if strings.HasPrefix(s, "\xff\xfe") {
+		s = s[2:]
+	} else if strings.HasPrefix(s, "\xef\xbb\xbf") {
+		s = s[3:]
+	}
 }
 
 func fn3() {


### PR DESCRIPTION
This generally makes code less clear; e.g. the "fixed" version for the added test would be:

	if strings.HasPrefix(data, "\xff\xfe") {
		data = data[2:]
	} else {
		data = strings.TrimPrefix("\xef\xbb\xbf")
	}

It already skipped cases with an "else" branch.

Fixes #1447