### PR TITLE
SA1006: flag more functions

### DIFF
--- a/staticcheck/sa1006/sa1006.go
+++ b/staticcheck/sa1006/sa1006.go
@@ -91,6 +91,9 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			_, alt, _ = strings.Cut(alt, ")")
 			alt = call.Fun.(*ast.SelectorExpr).X.(*ast.Ident).Name + alt
 		}
+		if name == "fmt.Errorf" { // Special case.
+			alt = "errors.New"
+		}
 		report.Report(pass, call,
 			"printf-style function with dynamic format string and no further arguments should use print-style function instead",
 			report.Fixes(edit.Fix(fmt.Sprintf("use %s instead of %s", alt, name), edit.ReplaceWithString(call.Fun, alt))))

--- a/staticcheck/sa1006/testdata/src/example.com/CheckUnsafePrintf/CheckUnsafePrintf.go
+++ b/staticcheck/sa1006/testdata/src/example.com/CheckUnsafePrintf/CheckUnsafePrintf.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"testing"
 )
 
 func fn(s string) {
@@ -20,6 +21,28 @@ func fn(s string) {
 	fmt.Printf("")
 	fmt.Printf("%s", "")
 	fmt.Printf(fn3())
+
+	l := log.New(os.Stdout, "", 0)
+	l.Printf("xx: %q", "yy")
+	l.Printf(s) //@ diag(`should use print-style function`)
+
+	var t testing.T
+	t.Logf(fn2()) //@ diag(`should use print-style function`)
+	t.Errorf(s)   //@ diag(`should use print-style function`)
+	t.Fatalf(s)   //@ diag(`should use print-style function`)
+	t.Skipf(s)    //@ diag(`should use print-style function`)
+
+	var b testing.B
+	b.Logf(fn2()) //@ diag(`should use print-style function`)
+	b.Errorf(s)   //@ diag(`should use print-style function`)
+	b.Fatalf(s)   //@ diag(`should use print-style function`)
+	b.Skipf(s)    //@ diag(`should use print-style function`)
+
+	var tb testing.TB
+	tb.Logf(fn2()) //@ diag(`should use print-style function`)
+	tb.Errorf(s)   //@ diag(`should use print-style function`)
+	tb.Fatalf(s)   //@ diag(`should use print-style function`)
+	tb.Skipf(s)    //@ diag(`should use print-style function`)
 }
 
 func fn3() (string, int) { return "", 0 }

--- a/staticcheck/sa1006/testdata/src/example.com/CheckUnsafePrintf/CheckUnsafePrintf.go
+++ b/staticcheck/sa1006/testdata/src/example.com/CheckUnsafePrintf/CheckUnsafePrintf.go
@@ -43,6 +43,8 @@ func fn(s string) {
 	tb.Errorf(s)   //@ diag(`should use print-style function`)
 	tb.Fatalf(s)   //@ diag(`should use print-style function`)
 	tb.Skipf(s)    //@ diag(`should use print-style function`)
+
+	fmt.Errorf(s) //@ diag(`should use print-style function`)
 }
 
 func fn3() (string, int) { return "", 0 }

--- a/staticcheck/sa1006/testdata/src/example.com/CheckUnsafePrintf/CheckUnsafePrintf.go.golden
+++ b/staticcheck/sa1006/testdata/src/example.com/CheckUnsafePrintf/CheckUnsafePrintf.go.golden
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"testing"
 )
 
 func fn(s string) {
@@ -20,6 +21,28 @@ func fn(s string) {
 	fmt.Printf("")
 	fmt.Printf("%s", "")
 	fmt.Printf(fn3())
+
+	l := log.New(os.Stdout, "", 0)
+	l.Printf("xx: %q", "yy")
+	l.Print(s) //@ diag(`should use print-style function`)
+
+	var t testing.T
+	t.Log(fn2()) //@ diag(`should use print-style function`)
+	t.Error(s)   //@ diag(`should use print-style function`)
+	t.Fatal(s)   //@ diag(`should use print-style function`)
+	t.Skip(s)    //@ diag(`should use print-style function`)
+
+	var b testing.B
+	b.Log(fn2()) //@ diag(`should use print-style function`)
+	b.Error(s)   //@ diag(`should use print-style function`)
+	b.Fatal(s)   //@ diag(`should use print-style function`)
+	b.Skip(s)    //@ diag(`should use print-style function`)
+
+	var tb testing.TB
+	tb.Log(fn2()) //@ diag(`should use print-style function`)
+	tb.Error(s)   //@ diag(`should use print-style function`)
+	tb.Fatal(s)   //@ diag(`should use print-style function`)
+	tb.Skip(s)    //@ diag(`should use print-style function`)
 }
 
 func fn3() (string, int) { return "", 0 }

--- a/staticcheck/sa1006/testdata/src/example.com/CheckUnsafePrintf/CheckUnsafePrintf.go.golden
+++ b/staticcheck/sa1006/testdata/src/example.com/CheckUnsafePrintf/CheckUnsafePrintf.go.golden
@@ -43,6 +43,8 @@ func fn(s string) {
 	tb.Error(s)   //@ diag(`should use print-style function`)
 	tb.Fatal(s)   //@ diag(`should use print-style function`)
 	tb.Skip(s)    //@ diag(`should use print-style function`)
+
+	errors.New(s) //@ diag(`should use print-style function`)
 }
 
 func fn3() (string, int) { return "", 0 }


### PR DESCRIPTION
Flag all stdlib functions that have both a Printf() and Print() variant.

Found with:

    % rg -g '!internal/' -g '!cmd/' '^func ([()*a-zA-Z0-9_ ]+)?[A-Z]\w+\(\w+ string, \w+ \.\.\.any\)'

(will need to filter out some false positives)

Fixes #1528