### PR TITLE
lintcmd: don't print \' in -list-checks and -explain

### DIFF
--- a/analysis/lint/lint.go
+++ b/analysis/lint/lint.go
@@ -155,25 +155,25 @@ func (doc *Documentation) format(markdown bool, metadata bool) string {
 	if markdown {
 		fmt.Fprintf(b, "%s\n\n", doc.TitleMarkdown)
 		if doc.Text != "" {
-			fmt.Fprintf(b, "%s\n\n", doc.TextMarkdown)
+			fmt.Fprintf(b, "%s\n\n", strings.TrimSpace(doc.TextMarkdown))
 		}
 	} else {
 		fmt.Fprintf(b, "%s\n\n", doc.Title)
 		if doc.Text != "" {
-			fmt.Fprintf(b, "%s\n\n", doc.Text)
+			fmt.Fprintf(b, "%s\n\n", strings.TrimSpace(doc.Text))
 		}
 	}
 
 	if doc.Before != "" {
 		fmt.Fprintln(b, "Before:")
 		fmt.Fprintln(b, "")
-		for _, line := range strings.Split(doc.Before, "\n") {
+		for _, line := range strings.Split(strings.TrimSpace(doc.Before), "\n") {
 			fmt.Fprint(b, "    ", line, "\n")
 		}
 		fmt.Fprintln(b, "")
 		fmt.Fprintln(b, "After:")
 		fmt.Fprintln(b, "")
-		for _, line := range strings.Split(doc.After, "\n") {
+		for _, line := range strings.Split(strings.TrimSpace(doc.After), "\n") {
 			fmt.Fprint(b, "    ", line, "\n")
 		}
 		fmt.Fprintln(b, "")

--- a/lintcmd/cmd.go
+++ b/lintcmd/cmd.go
@@ -344,6 +344,8 @@ func (cmd *Command) printDebugVersion() int {
 	return 0
 }
 
+var quoteReplacer = strings.NewReplacer(`\'`, `'`, `\"`, `"`)
+
 func (cmd *Command) listChecks() int {
 	cs := cmd.analyzersAsSlice()
 	sort.Slice(cs, func(i, j int) bool {
@@ -354,7 +356,7 @@ func (cmd *Command) listChecks() int {
 		if c.Doc != nil {
 			title = c.Doc.Title
 		}
-		fmt.Printf("%s %s\n", c.Analyzer.Name, title)
+		fmt.Printf("%s %s\n", c.Analyzer.Name, quoteReplacer.Replace(title))
 	}
 	return 0
 }
@@ -375,7 +377,7 @@ func (cmd *Command) explain() int {
 		fmt.Fprintln(os.Stderr, explain, "has no documentation")
 		return 1
 	}
-	fmt.Println(check.Doc)
+	fmt.Println(quoteReplacer.Replace(check.Doc.String()))
 	fmt.Println("Online documentation\n    https://staticcheck.dev/docs/checks#" + check.Analyzer.Name)
 	return 0
 }


### PR DESCRIPTION
All the single quotes are written as `\'` in the descriptions. I assume that's for a good reason, but -list-checks would print:

    % staticcheck -list-checks | grep "'"
    S1003 Replace call to \'strings.Index\' with \'strings.Contains\'
    S1004 Replace call to \'bytes.Compare\' with \'bytes.Equal\'
    S1011 Use a single \'append\' to concatenate two slices
    S1012 Replace \'time.Now().Sub(x)\' with \'time.Since(x)\'
    ...

    % staticcheck -explain S1003
    Replace call to \'strings.Index\' with \'strings.Contains\'

So fix that:

    % staticcheck -list-checks | grep "'"
    S1003 Replace call to 'strings.Index' with 'strings.Contains'
    S1004 Replace call to 'bytes.Compare' with 'bytes.Equal'
    S1011 Use a single 'append' to concatenate two slices
    S1012 Replace 'time.Now().Sub(x)' with 'time.Since(x)'
    ...

    % staticcheck -explain S1003
    Replace call to 'strings.Index' with 'strings.Contains'

As an added bonus, make `-explain s1003` (lower case) work. Seemed too small of a change to make a new PR for.