### PR TITLE
lintcmd: make -check case-insensitive, error on unknown checks

### DIFF
--- a/lintcmd/cmd.go
+++ b/lintcmd/cmd.go
@@ -678,7 +678,11 @@ func (cmd *Command) printDiagnostics(cs []*lint.Analyzer, diagnostics []diagnost
 	for i, a := range cs {
 		analyzerNames[i] = a.Analyzer.Name
 	}
-	shouldExit := filterAnalyzerNames(analyzerNames, fail)
+	shouldExit, err := filterAnalyzerNames(analyzerNames, fail)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		return 1
+	}
 	shouldExit["staticcheck"] = true
 	shouldExit["compile"] = true
 

--- a/lintcmd/lint_test.go
+++ b/lintcmd/lint_test.go
@@ -1,0 +1,80 @@
+package lintcmd
+
+import (
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestFilterAnalyzerNames(t *testing.T) {
+	analyzers := []string{
+		"S1000", "S1001",
+		"SA1000", "SA1001",
+		"SA2000", "SA2001",
+		"ST1000", "ST1001",
+		"U1000",
+	}
+	all := make(map[string]bool)
+	for _, a := range analyzers {
+		all[a] = true
+	}
+	allMinus := func(minus ...string) map[string]bool {
+		m := make(map[string]bool)
+		for k := range all {
+			m[k] = !slices.Contains(minus, k)
+		}
+		return m
+	}
+
+	tests := []struct {
+		in      []string
+		want    map[string]bool
+		wantErr string
+	}{
+		{[]string{"all"}, all, ""},
+		{[]string{"All"}, all, ""},
+		{[]string{"*"}, all, ""},
+
+		{[]string{"S*"}, map[string]bool{"S1000": true, "S1001": true}, ""},
+		{[]string{"SA1*"}, map[string]bool{"SA1000": true, "SA1001": true}, ""},
+		{[]string{"SA2*"}, map[string]bool{"SA2000": true, "SA2001": true}, ""},
+		{[]string{"SA*"}, map[string]bool{"SA1000": true, "SA1001": true, "SA2000": true, "SA2001": true}, ""},
+
+		{[]string{"S1000", "st1000"}, map[string]bool{"S1000": true, "ST1000": true}, ""},
+
+		{[]string{"SA9*"}, nil, "matched no checks"},
+		{[]string{"S*", "SA9*"}, nil, "matched no checks"},
+		{[]string{"SA9*", "all"}, nil, "matched no checks"},
+
+		{[]string{"S9999"}, nil, "unknown check"},
+		{[]string{"check"}, nil, "unknown check"},
+		{[]string{`!@#'"`}, nil, "unknown check"},
+
+		{[]string{"all", "-S1000"}, allMinus("S1000"), ""},
+		{[]string{"all", "-SA1*"}, allMinus("SA1000", "SA1001"), ""},
+		{[]string{"-S1000", "all"}, all, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			have, haveErr := filterAnalyzerNames(analyzers, tt.in)
+			if !errorContains(haveErr, tt.wantErr) {
+				t.Fatalf("wrong error:\nhave: %s\nwant: %s", haveErr, tt.wantErr)
+			}
+			if !reflect.DeepEqual(have, tt.want) {
+				t.Fatalf("\nhave: %v\nwant: %v", have, tt.want)
+			}
+		})
+	}
+}
+
+func errorContains(have error, want string) bool {
+	if have == nil {
+		return want == ""
+	}
+	if want == "" {
+		return false
+	}
+	return strings.Contains(have.Error(), want)
+}


### PR DESCRIPTION
This changes it so that the check is case-insensitive, and so it will return an error on unknown checks. Previously:

	% staticcheck -checks=sa1000 ./lintcmd
	[no output, exit 0]

	% staticcheck -checks=banana ./lintcmd
	[no output, exit 0]

	% staticcheck -checks=SA1000 ./lintcmd
	lintcmd/cmd.go:270:34: error parsing regexp: missing closing ): `$^(` (SA1000)

This is massively confusing! When I was doing my testing for the other PRs yesterday I found it odd that I didn't get any error for the defer one, since I *knew* there was at least one module with this error. Turned out it just always passed because I used lower-case.

I wouldn't be surprised if tons of people have made this mistake and have run (or are running) staticcheck runs that don't actually do anything.

All of this also applies to checks = [..] from the config file.