### PR TITLE
lintcmd: print TOML error on invalid config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module honnef.co/go/tools
 go 1.22
 
 require (
-	github.com/BurntSushi/toml v1.3.2
+	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa
 	golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678
 	golang.org/x/sys v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
-github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c h1:pxW6RcqyfI9/kWtOwnv/G+AzdKuy2ZrqINhenH4HyNs=
+github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa h1:FRnLl4eNAQl8hwxVVC17teOw8kdjVDVAiFMtgUdTSRQ=
 golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa/go.mod h1:zk2irFbV9DP96SEBUUAy67IdHUaZuSnrz1n472HUCLE=
 golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 h1:1P7xPZEwZMoBoz0Yze5Nx2/4pxj6nw9ZqHWXqP0iRgQ=

--- a/go/loader/loader.go
+++ b/go/loader/loader.go
@@ -336,7 +336,7 @@ func convertError(err error) []packages.Error {
 
 	case config.ParseError:
 		errs = append(errs, packages.Error{
-			Pos:  fmt.Sprintf("%s:%d", err.Filename, err.Position.Line),
+			Pos:  fmt.Sprintf("%s:%d:%d", err.Filename, err.Position.Line, err.Position.Col),
 			Msg:  fmt.Sprintf("%s (last key parsed: %q)", err.Message, err.LastKey),
 			Kind: packages.ParseError,
 		})

--- a/lintcmd/lint.go
+++ b/lintcmd/lint.go
@@ -429,6 +429,11 @@ func failed(res runner.Result) []diagnostic {
 				msg = msg[1:]
 			}
 
+			cat := "compile"
+			if e.Kind == packages.ParseError {
+				cat = "config"
+			}
+
 			var posn token.Position
 			if e.Pos == "" {
 				// Under certain conditions (malformed package
@@ -456,7 +461,7 @@ func failed(res runner.Result) []diagnostic {
 				Diagnostic: runner.Diagnostic{
 					Position: posn,
 					Message:  msg,
-					Category: "compile",
+					Category: cat,
 				},
 				Severity: severityError,
 			}


### PR DESCRIPTION
Previously the error message would get lost:

    % staticcheck
    staticcheck.conf:5:0:  (last key parsed: "dot_import_whitelist") (compile)

This is actually my bug; the ParseError.Message wasn't always set; fixed with: https://github.com/BurntSushi/toml/pull/411

Also print a more verbose errors, which is nicer IMHO:

    % staticcheck
    staticcheck.conf:5:60: toml: error: expected a comma (',') or array terminator (']'), but got '"'

    At line 5, column 60:

          3 |
          4 | checks = ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022", "-ST1023"]
          5 | dot_import_whitelist = ["github.com/mmcloughlin/avo/build" "github.com/mmcloughlin/avo/operand", "github.com/mmcloughlin/avo/reg"]
                                                                         ^
     (config)

    % staticcheck -f stylish
    /home/martin/src/go-tools/staticcheck.conf
      (5, 60)  config  toml: error: expected a comma (',') or array terminator (']'), but got '"'

    At line 5, column 60:

          3 |
          4 | checks = ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022", "-ST1023"]
          5 | dot_import_whitelist = ["github.com/mmcloughlin/avo/build" "github.com/mmcloughlin/avo/operand", "github.com/mmcloughlin/avo/reg"]
                                                                         ^

     ✖ 1 problems (0 errors, 1 warnings, 0 ignored)

    % staticcheck -f json | jfmt
    {
        "code":     "config",
        "end":      {"column": 0, "file": "", "line": 0},
        "location": {"column": 60, "file": "/home/martin/src/go-tools/staticcheck.conf", "line": 5},
        "message":  "toml: error: expected a comma (',') or array terminator (']'), but got '\"'\n\nAt line 5, column 60:\n\n      3 | \n      4 | checks = [\"all\", \"-ST1000\", \"-ST1003\", \"-ST1016\", \"-ST1020\", \"-ST1021\", \"-ST1022\", \"-ST1023\"]\n      5 | dot_import_whitelist = [\"github.com/mmcloughlin/avo/build\" \"github.com/mmcloughlin/avo/operand\", \"github.com/mmcloughlin/avo/reg\"]\n
                                  ^\n",
        "severity": "warning"
    }