### PR TITLE
S1008: don't flag if both branches are commented

### DIFF
--- a/simple/s1008/testdata/go1.0/CheckIfReturn/comment.go
+++ b/simple/s1008/testdata/go1.0/CheckIfReturn/comment.go
@@ -1,0 +1,47 @@
+package pkg
+
+func cmt1(x string) bool {
+	// A
+	if len(x) > 0 {
+		return false
+	}
+	// B
+	return true
+}
+
+func cmt2(x string) bool {
+	if len(x) > 0 { // A
+		return false
+	}
+	return true // B
+}
+
+func cmt3(x string) bool {
+	if len(x) > 0 {
+		return false // A
+	}
+	return true // B
+}
+
+func cmt4(x string) bool {
+	if len(x) > 0 {
+		return false // A
+	}
+	return true
+	// B
+}
+
+// Hard to test, as the diag line adds a comment.
+//func cmt5(x string) bool {
+//	if len(x) > 0 { // diag(`should use 'return len(x) == 0'`)
+//		return false
+//	}
+//	return true // A
+//}
+
+func cmt6(x string) bool {
+	if len(x) > 0 { //@diag(`should use 'return len(x) == 0'`)
+		return false // A
+	}
+	return true
+}


### PR DESCRIPTION
Only skip if both branches are documented; in cases where just one is commented it can just be:

	// Comment it.
	return [..]

Closes: gh-704
Closes: gh-1488