### PR TITLE
Make lintcmd usable from a library, without it calling os.Exit()

### DIFF
--- a/lintcmd/cmd.go
+++ b/lintcmd/cmd.go
@@ -271,9 +271,9 @@ func decodeGob(br io.ByteReader) ([]run, error) {
 	return runs, nil
 }
 
-// Run runs all registered analyzers and reports their findings.
-// It always calls os.Exit and does not return.
-func (cmd *Command) Run() {
+// Execute runs all registered analyzers and reports their findings.
+// The status code returned can be used for os.Exit(cmd.Execute()).
+func (cmd *Command) Execute() int {
 	// Set up profiling and tracing
 	if path := cmd.flags.debugCpuprofile; path != "" {
 		f, err := os.Create(path)
@@ -331,6 +331,14 @@ func (cmd *Command) Run() {
 	if cmd.flags.debugTrace != "" {
 		trace.Stop()
 	}
+
+	return exit
+}
+
+// Run runs all registered analyzers and reports their findings.
+// It always calls os.Exit and does not return.
+func (cmd *Command) Run() {
+	exit := cmd.Execute()
 
 	// Exit with appropriate status
 	os.Exit(exit)


### PR DESCRIPTION
This PR splits most of `func (cmd *Command) Run()` off into `func (cmd *Command) Execute() int`. My goal is to be able to run staticcheck from a Go program without it calling `os.Exit()`.

Some background: for my Go projects I'm trying to lower the barrier of entry for developers as much as possible. I'm using [Magefile][m] to build my tool [Skyfill][s]. Magefile is a build tool that is written in Go, and thus can be run with just `go run mage.go` without manually installing anything first (except Go itself). As the build script is written in Go as well, I can call tools like staticcheck, govulncheck, etc. directly from go, instead of getting them installed on $PATH first.

This PR makes it nicer to integrate staticcheck in my build chain; because it doesn't unconditionally call `os.Exit()` any more, it means that I can use it concurrently with other tools / build steps.

[m]: https://magefile.org/
[s]: https://stuvel.eu/software/skyfill/