### PR TITLE
Add "go install" command to the startpage

### DIFF
--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -9,6 +9,9 @@ title: Staticcheck
 Staticcheck is a state of the art linter for the Go programming language.
 Using static analysis, it finds bugs and performance issues, offers simplifications, and enforces style rules.
 
+Install Staticcheck by running:
+
+    go install honnef.co/go/tools/cmd/staticcheck@latest
 
 <div class="mx-auto">
 	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="{{< relref "/docs" >}}">


### PR DESCRIPTION
I had to re-install staticcheck on a few machines, and every time I was slightly annoyed that I had to click two pages in to find the right URL.  I think that presenting the information right away would be just that tad more convenient.