### PR TITLE
website: add defaults for dot_import_whitelist

### DIFF
--- a/website/content/docs/configuration/options.md
+++ b/website/content/docs/configuration/options.md
@@ -33,7 +33,7 @@ all uses of dot imports in non-test packages. This
 setting allows setting a whitelist of import paths that can
 be dot-imported anywhere.
 
-Default value: `[]`
+Default value: `["github.com/mmcloughlin/avo/build", "github.com/mmcloughlin/avo/operand", "github.com/mmcloughlin/avo/reg"]`
 
 ## http_status_code_whitelist {#http_status_code_whitelist}
 


### PR DESCRIPTION
This PR modifies `options.md` by adding default values for the `dot_import_whitelist` option.

See https://github.com/dominikh/go-tools/blob/cdd14abaf8eddb869706f0eb52df2a6c82d95b40/config/config.go#L176-L180