### PR TITLE
all: fix typos in comments; remove dupwords

### DIFF
--- a/analysis/code/code.go
+++ b/analysis/code/code.go
@@ -178,7 +178,7 @@ func CallName(pass *analysis.Pass, call *ast.CallExpr) string {
 		fun = idx.X
 	}
 
-	// (foo)[T] is not a valid instantiationg, so no need to unparen again.
+	// (foo)[T] is not a valid instantiation, so no need to unparen again.
 
 	switch fun := fun.(type) {
 	case *ast.SelectorExpr:
@@ -525,7 +525,7 @@ func StdlibVersion(pass *analysis.Pass, node Positioner) string {
 			// Do note that strictly speaking we're conflating the Go version and the
 			// module version in our check. Nothing is stopping a user from using Go 1.17
 			// (which didn't implement the new rules for versions in go.mod) to build a Go
-			// 1.22 module, in which case a file tagged with go1.17 will not have acces to the 1.22
+			// 1.22 module, in which case a file tagged with go1.17 will not have access to the 1.22
 			// standard library. However, we believe that if a module requires 1.21 or
 			// newer, then the author clearly expects the new behavior, and doesn't care
 			// for the old one. Otherwise they would've specified an older version.

--- a/go/ir/builder.go
+++ b/go/ir/builder.go
@@ -895,7 +895,7 @@ func (b *builder) stmtList(fn *Function, list []ast.Stmt) {
 // returns the effective receiver after applying the implicit field
 // selections of sel.
 //
-// wantAddr requests that the result is an an address.  If
+// wantAddr requests that the result is an address.  If
 // !sel.Indirect(), this may require that e be built in addr() mode; it
 // must thus be addressable.
 //
@@ -2058,7 +2058,7 @@ func (b *builder) forStmtGo122(fn *Function, s *ast.ForStmt, label *lblock) {
 		fn.emit(phi, lhs)
 
 		fn.currentBlock = post
-		// If next is is local, it reuses the address and zeroes the old value so
+		// If next is local, it reuses the address and zeroes the old value so
 		// load before allocating next.
 		load := emitLoad(fn, phi, init)
 		next := emitLocal(fn, v.Type(), lhs, v.Name())
@@ -3153,7 +3153,7 @@ func (b *builder) buildFunction(fn *Function) {
 func (b *builder) buildYieldFunc(fn *Function) {
 	// See builder.rangeFunc for detailed documentation on how fn is set up.
 	//
-	// In psuedo-Go this roughly builds:
+	// In pseudo-Go this roughly builds:
 	// func yield(_k tk, _v tv) bool {
 	//         if jump != READY { panic("yield function called after range loop exit") }
 	//     jump = BUSY

--- a/go/ir/emit.go
+++ b/go/ir/emit.go
@@ -156,7 +156,7 @@ func emitArith(f *Function, op token.Token, x, y Value, t types.Type, source ast
 }
 
 // emitCompare emits to f code compute the boolean result of
-// comparison comparison 'x op y'.
+// comparison 'x op y'.
 func emitCompare(f *Function, op token.Token, x, y Value, source ast.Node) Value {
 	xt := x.Type().Underlying()
 	yt := y.Type().Underlying()

--- a/go/ir/source_test.go
+++ b/go/ir/source_test.go
@@ -54,7 +54,7 @@ func TestObjValueLookup(t *testing.T) {
 
 	// Each note of the form @ir(x, "BinOp") in testdata/objlookup.go
 	// specifies an expectation that an object named x declared on the
-	// same line is associated with an an ir.Value of type *ir.BinOp.
+	// same line is associated with an ir.Value of type *ir.BinOp.
 	notes, err := expect.ExtractGo(conf.Fset, f)
 	if err != nil {
 		t.Fatal(err)

--- a/knowledge/deprecated.go
+++ b/knowledge/deprecated.go
@@ -164,7 +164,7 @@ var StdlibDeprecations = map[string]Deprecation{
 	"syscall.GetQueuedCompletionStatus":     {"go1.17", "go1.0"},
 	"syscall.CreateIoCompletionPort":        {"go1.17", "go1.0"},
 
-	// We choose to only track the package itself, even though all functions are derecated individually, too. Anyone
+	// We choose to only track the package itself, even though all functions are deprecated individually, too. Anyone
 	// using ioutil directly will have to import it, and this keeps the noise down.
 	"io/ioutil": {"go1.19", "go1.19"},
 

--- a/staticcheck/sa9007/sa9007.go
+++ b/staticcheck/sa9007/sa9007.go
@@ -24,7 +24,7 @@ var SCAnalyzer = lint.InitializeAnalyzer(&lint.Analyzer{
 		Text: `
 It is virtually never correct to delete system directories such as
 /tmp or the user's home directory. However, it can be fairly easy to
-do by mistake, for example by mistakingly using \'os.TempDir\' instead
+do by mistake, for example by mistakenly using \'os.TempDir\' instead
 of \'ioutil.TempDir\', or by forgetting to add a suffix to the result
 of \'os.UserHomeDir\'.
 

--- a/unused/unused.go
+++ b/unused/unused.go
@@ -888,7 +888,7 @@ func (g *graph) read(node ast.Node, by types.Object) {
 			g.read(arg, by)
 		}
 
-		// Handle conversiosn
+		// Handle conversions
 		conv := node
 		if len(conv.Args) != 1 || conv.Ellipsis.IsValid() {
 			return


### PR DESCRIPTION
The PR fixes typos in comments and removes duplicated words.