### PR TITLE
staticcheck: add documentation text to select checks

### DIFF
--- a/staticcheck/sa1002/sa1002.go
+++ b/staticcheck/sa1002/sa1002.go
@@ -21,6 +21,7 @@ var SCAnalyzer = lint.InitializeAnalyzer(&lint.Analyzer{
 	},
 	Doc: &lint.RawDocumentation{
 		Title:    `Invalid format in \'time.Parse\'`,
+		Text:     `\'time.Parse\' requires a layout string that uses Go's reference time: \'Mon Jan 2 15:04:05 MST 2006\' (Unix date format). The layout must represent this date and time exactly. See https://pkg.go.dev/time#pkg-constants for layout examples.`,
 		Since:    "2017.1",
 		Severity: lint.SeverityError,
 		MergeIf:  lint.MergeIfAny,

--- a/staticcheck/sa1012/sa1012.go
+++ b/staticcheck/sa1012/sa1012.go
@@ -22,6 +22,7 @@ var SCAnalyzer = lint.InitializeAnalyzer(&lint.Analyzer{
 	},
 	Doc: &lint.RawDocumentation{
 		Title:    `A nil \'context.Context\' is being passed to a function, consider using \'context.TODO\' instead`,
+		Text:     `A \'nil\' context is almost always incorrect and should be avoided. If no parent context is available, a new context should be used, e.g. \'context.TODO\' or \'context.Background\'.`,
 		Since:    "2017.1",
 		Severity: lint.SeverityWarning,
 		MergeIf:  lint.MergeIfAny,

--- a/staticcheck/sa1014/sa1014.go
+++ b/staticcheck/sa1014/sa1014.go
@@ -19,6 +19,7 @@ var SCAnalyzer = lint.InitializeAnalyzer(&lint.Analyzer{
 	},
 	Doc: &lint.RawDocumentation{
 		Title:    `Non-pointer value passed to \'Unmarshal\' or \'Decode\'`,
+		Text:     `Functions such as \'json.Unmarshal\' and \'json.(*Decoder).Decode\' require a pointer to the value that should be populated. Passing a non-pointer value results in the function returning an error at runtime, as it cannot modify the target value.`,
 		Since:    "2017.1",
 		Severity: lint.SeverityError,
 		MergeIf:  lint.MergeIfAny,

--- a/staticcheck/sa1020/sa1020.go
+++ b/staticcheck/sa1020/sa1020.go
@@ -21,6 +21,7 @@ var SCAnalyzer = lint.InitializeAnalyzer(&lint.Analyzer{
 	},
 	Doc: &lint.RawDocumentation{
 		Title:    `Using an invalid host:port pair with a \'net.Listen\'-related function`,
+		Text:     `Functions such as \'net.Listen\', \'net.ListenTCP\', and similar, expect a valid network address in the form of host:port. The host, the port, or both, can be omitted, e.g. \'localhost:8080\', \':8080\' or \':\' are valid host:port pairs. See https://pkg.go.dev/net#Listen for the full documentation.`,
 		Since:    "2017.1",
 		Severity: lint.SeverityError,
 		MergeIf:  lint.MergeIfAny,

--- a/staticcheck/sa2000/sa2000.go
+++ b/staticcheck/sa2000/sa2000.go
@@ -19,7 +19,8 @@ var SCAnalyzer = lint.InitializeAnalyzer(&lint.Analyzer{
 		Requires: code.RequiredAnalyzers,
 	},
 	Doc: &lint.RawDocumentation{
-		Title:    `\'sync.WaitGroup.Add\' called inside the goroutine, leading to a race condition`,
+		Title:    `\'sync.(*WaitGroup).Add\' called inside the goroutine, leading to a race condition`,
+		Text:     `\'sync.(*WaitGroup).Add\' must be called before starting the goroutine it is meant to wait for. Calling \'Add\' inside the goroutine creates a race condition between the call to \'Add\' and the call to \'Wait\'.`,
 		Since:    "2017.1",
 		Severity: lint.SeverityWarning,
 		MergeIf:  lint.MergeIfAny,

--- a/staticcheck/sa2003/sa2003.go
+++ b/staticcheck/sa2003/sa2003.go
@@ -21,6 +21,7 @@ var SCAnalyzer = lint.InitializeAnalyzer(&lint.Analyzer{
 	},
 	Doc: &lint.RawDocumentation{
 		Title:    `Deferred \'Lock\' right after locking, likely meant to defer \'Unlock\' instead`,
+		Text:     `Deferring \'Lock\' immediately after locking will cause a deadlock. Use \'Unlock\' instead.`,
 		Since:    "2017.1",
 		Severity: lint.SeverityWarning,
 		MergeIf:  lint.MergeIfAny,

--- a/staticcheck/sa4010/sa4010.go
+++ b/staticcheck/sa4010/sa4010.go
@@ -17,6 +17,7 @@ var SCAnalyzer = lint.InitializeAnalyzer(&lint.Analyzer{
 	},
 	Doc: &lint.RawDocumentation{
 		Title:    `The result of \'append\' will never be observed anywhere`,
+		Text:     `Calls to \'append\' produce a new slice value that must be used. When the result of \'append\' is assigned to a variable that is never subsequently read, or is immediately overwritten, the append operation has no effect.`,
 		Since:    "2017.1",
 		Severity: lint.SeverityWarning,
 		MergeIf:  lint.MergeIfAll,


### PR DESCRIPTION
This PR introduces documentation text for the following checks:

- SA1002
- SA1012
- SA1014
- SA1020
- SA2000
- SA2003
- SA4010

It also updates the format of the method reference in the `Title` string to be consistent with other parts of the staticcheck
documentation and the Go community conventions.

