### PR TITLE
SA1027: add s390x support to test file

### DIFF
--- a/staticcheck/sa1027/testdata/go1.0/CheckAtomicAlignment/atomic64.go
+++ b/staticcheck/sa1027/testdata/go1.0/CheckAtomicAlignment/atomic64.go
@@ -1,4 +1,4 @@
-// +build amd64 amd64p32 arm64 ppc64 ppc64le mips64 mips64le mips64p32 mips64p32le sparc64 riscv64 loong64
+// +build amd64 amd64p32 arm64 ppc64 ppc64le mips64 mips64le mips64p32 mips64p32le s390x sparc64 riscv64 loong64
 
 package pkg
 


### PR DESCRIPTION
This fails to find any test data without the `s390x` build tag, and the test would fail.