### PR TITLE
QF1012 : b.WriteString(x + y) -> b.WriteString(s); b.WriteString(y) #1684

### DIFF
--- a/analysis/edit/edit.go
+++ b/analysis/edit/edit.go
@@ -46,6 +46,19 @@ func ReplaceWithNode(fset *token.FileSet, old Ranger, new ast.Node) analysis.Tex
 	}
 }
 
+// ReplaceWithStatements replaces a range with statements.
+func ReplaceWithStatements(fset *token.FileSet, old Ranger, new ...ast.Stmt) analysis.TextEdit {
+	buf := &bytes.Buffer{}
+	if err := format.Node(buf, fset, new); err != nil {
+		panic("internal error: " + err.Error())
+	}
+	return analysis.TextEdit{
+		Pos:     old.Pos(),
+		End:     old.End(),
+		NewText: buf.Bytes(),
+	}
+}
+
 // ReplaceWithPattern replaces a range with the result of executing a pattern.
 func ReplaceWithPattern(fset *token.FileSet, old Ranger, new pattern.Pattern, state pattern.State) analysis.TextEdit {
 	r := pattern.NodeToAST(new.Root, state)

--- a/quickfix/qf1012/qf1012.go
+++ b/quickfix/qf1012/qf1012.go
@@ -131,7 +131,7 @@ func run(pass *analysis.Pass) (any, error) {
 			}
 
 			concat := m.State["concat"].(ast.Expr)
-			concatLits := unwrapRight(concat)
+			concatLits := unwrapStringConcat(concat)
 
 			editStmts := make([]ast.Stmt, 0, len(concatLits))
 			for _, lit := range concatLits {
@@ -155,7 +155,7 @@ func run(pass *analysis.Pass) (any, error) {
 	return nil, nil
 }
 
-func unwrapRight(rightExpr ast.Expr) []*ast.BasicLit {
+func unwrapStringConcat(rightExpr ast.Expr) []*ast.BasicLit {
 	rightExpr = ast.Unparen(rightExpr)
 
 	if bin, ok := rightExpr.(*ast.BinaryExpr); ok {
@@ -163,8 +163,8 @@ func unwrapRight(rightExpr ast.Expr) []*ast.BasicLit {
 			return nil
 		}
 
-		xs := unwrapRight(bin.X)
-		ys := unwrapRight(bin.Y)
+		xs := unwrapStringConcat(bin.X)
+		ys := unwrapStringConcat(bin.Y)
 
 		all := make([]*ast.BasicLit, 0, len(xs)+len(ys))
 		all = append(all, xs...)

--- a/quickfix/qf1012/testdata/go1.0/CheckWriteBytesSprintf/CheckWriteBytesSprintf.go
+++ b/quickfix/qf1012/testdata/go1.0/CheckWriteBytesSprintf/CheckWriteBytesSprintf.go
@@ -39,3 +39,8 @@ func fn3() {
 	var buf bytes.Buffer
 	buf.WriteString(fmt.Sprint("abc", "de")) //@ diag(`Use fmt.Fprint`)
 }
+
+func fn4() {
+	var buf bytes.Buffer
+	buf.WriteString("abc" + "de") //@ diag(`Replace WriteString(x + y) with WriteString(x); WriteString(y)`)
+}

--- a/quickfix/qf1012/testdata/go1.0/CheckWriteBytesSprintf/CheckWriteBytesSprintf.go
+++ b/quickfix/qf1012/testdata/go1.0/CheckWriteBytesSprintf/CheckWriteBytesSprintf.go
@@ -43,4 +43,14 @@ func fn3() {
 func fn4() {
 	var buf bytes.Buffer
 	buf.WriteString("abc" + "de") //@ diag(`Replace WriteString(x + y) with WriteString(x); WriteString(y)`)
+
+	buf.WriteString(("(abc" + "de)")) //@ diag(`Replace WriteString(x + y) with WriteString(x); WriteString(y)`)
+
+	buf.WriteString(("(abc" + ("(de))"))) //@ diag(`Replace WriteString(x + y) with WriteString(x); WriteString(y)`)
+
+	buf.WriteString(("(abc)") + "de") //@ diag(`Replace WriteString(x + y) with WriteString(x); WriteString(y)`)
+
+	buf.WriteString("zxc" + "vb" + "n") //@ diag(`Replace WriteString(x + y) with WriteString(x); WriteString(y)`)
+
+	buf.WriteString(`zxc` + "vb" + `n`) //@ diag(`Replace WriteString(x + y) with WriteString(x); WriteString(y)`)
 }

--- a/quickfix/qf1012/testdata/go1.0/CheckWriteBytesSprintf/CheckWriteBytesSprintf.go.golden
+++ b/quickfix/qf1012/testdata/go1.0/CheckWriteBytesSprintf/CheckWriteBytesSprintf.go.golden
@@ -44,4 +44,21 @@ func fn4() {
 	var buf bytes.Buffer
 	buf.WriteString("abc")
 	buf.WriteString("de") //@ diag(`Replace WriteString(x + y) with WriteString(x); WriteString(y)`)
+
+	buf.WriteString("(abc")
+	buf.WriteString("de)") //@ diag(`Replace WriteString(x + y) with WriteString(x); WriteString(y)`)
+
+	buf.WriteString("(abc")
+	buf.WriteString("(de))") //@ diag(`Replace WriteString(x + y) with WriteString(x); WriteString(y)`)
+
+	buf.WriteString("(abc)")
+	buf.WriteString("de") //@ diag(`Replace WriteString(x + y) with WriteString(x); WriteString(y)`)
+
+	buf.WriteString("zxc")
+	buf.WriteString("vb")
+	buf.WriteString("n") //@ diag(`Replace WriteString(x + y) with WriteString(x); WriteString(y)`)
+
+	buf.WriteString(`zxc`)
+	buf.WriteString("vb")
+	buf.WriteString(`n`) //@ diag(`Replace WriteString(x + y) with WriteString(x); WriteString(y)`)
 }

--- a/quickfix/qf1012/testdata/go1.0/CheckWriteBytesSprintf/CheckWriteBytesSprintf.go.golden
+++ b/quickfix/qf1012/testdata/go1.0/CheckWriteBytesSprintf/CheckWriteBytesSprintf.go.golden
@@ -39,3 +39,9 @@ func fn3() {
 	var buf bytes.Buffer
 	fmt.Fprint(&buf, "abc", "de") //@ diag(`Use fmt.Fprint`)
 }
+
+func fn4() {
+	var buf bytes.Buffer
+	buf.WriteString("abc")
+	buf.WriteString("de") //@ diag(`Replace WriteString(x + y) with WriteString(x); WriteString(y)`)
+}


### PR DESCRIPTION
Adds support for a simple string concat into QF1012 as mentioned in https://github.com/dominikh/go-tools/issues/1684.

I'd be glad to provide the fixes you think are necessary.
