### PR TITLE
SA1026, SA9005: check MarshalIndent functions

### DIFF
--- a/knowledge/arg.go
+++ b/knowledge/arg.go
@@ -28,6 +28,7 @@ var Args = map[string]int{
 	"fmt.Sprintf.a[0]":                       1,
 	"fmt.Sprintf.format":                     0,
 	"json.Marshal.v":                         0,
+	"json.MarshalIndent.v":                   0,
 	"json.Unmarshal.v":                       1,
 	"len.v":                                  0,
 	"make.size[0]":                           1,
@@ -60,6 +61,7 @@ var Args = map[string]int{
 	"time.Parse.layout":                      0,
 	"time.Sleep.d":                           0,
 	"xml.Marshal.v":                          0,
+	"xml.MarshalIndent.v":                    0,
 	"xml.Unmarshal.v":                        1,
 }
 

--- a/staticcheck/sa1026/sa1026.go
+++ b/staticcheck/sa1026/sa1026.go
@@ -31,7 +31,9 @@ var Analyzer = SCAnalyzer.Analyzer
 
 var rules = map[string]callcheck.Check{
 	"encoding/json.Marshal":           checkJSON,
+	"encoding/json.MarshalIndent":     checkJSON,
 	"encoding/xml.Marshal":            checkXML,
+	"encoding/xml.MarshalIndent":      checkXML,
 	"(*encoding/json.Encoder).Encode": checkJSON,
 	"(*encoding/xml.Encoder).Encode":  checkXML,
 }

--- a/staticcheck/sa1026/testdata/go1.0/CheckUnsupportedMarshal/CheckUnsupportedMarshal.go
+++ b/staticcheck/sa1026/testdata/go1.0/CheckUnsupportedMarshal/CheckUnsupportedMarshal.go
@@ -322,3 +322,8 @@ func functionAsArgument(arg T1) {
 	json.Marshal(functionAsArgument) //@ diag(`unsupported type func(arg T1)`)
 	xml.Marshal(functionAsArgument)  //@ diag(`unsupported type func(arg T1)`)
 }
+
+func indent() {
+	json.MarshalIndent(functionAsArgument, "", "  ") //@ diag(`unsupported type func(arg T1)`)
+	xml.MarshalIndent(functionAsArgument, "", "  ")  //@ diag(`unsupported type func(arg T1)`)
+}

--- a/staticcheck/sa9005/sa9005.go
+++ b/staticcheck/sa9005/sa9005.go
@@ -50,7 +50,9 @@ var rules = map[string]callcheck.Check{
 	//
 	// Also, should we flag gob?
 	"encoding/json.Marshal":           check(knowledge.Arg("json.Marshal.v"), "MarshalJSON", "MarshalText"),
+	"encoding/json.MarshalIndent":     check(knowledge.Arg("json.MarshalIndent.v"), "MarshalJSON", "MarshalText"),
 	"encoding/xml.Marshal":            check(knowledge.Arg("xml.Marshal.v"), "MarshalXML", "MarshalText"),
+	"encoding/xml.MarshalIndent":      check(knowledge.Arg("xml.MarshalIndent.v"), "MarshalXML", "MarshalText"),
 	"(*encoding/json.Encoder).Encode": check(knowledge.Arg("(*encoding/json.Encoder).Encode.v"), "MarshalJSON", "MarshalText"),
 	"(*encoding/xml.Encoder).Encode":  check(knowledge.Arg("(*encoding/xml.Encoder).Encode.v"), "MarshalXML", "MarshalText"),
 

--- a/staticcheck/sa9005/testdata/go1.0/CheckNoopMarshal/CheckNoopMarshal.go
+++ b/staticcheck/sa9005/testdata/go1.0/CheckNoopMarshal/CheckNoopMarshal.go
@@ -53,7 +53,8 @@ func fn() {
 	// don't flag structs with no fields
 	json.Marshal(T1{})
 	// no exported fields
-	json.Marshal(T2{}) //@ diag(`struct type 'example.com/CheckNoopMarshal.T2' doesn't have any exported fields, nor custom marshaling`)
+	json.Marshal(T2{})                 //@ diag(`struct type 'example.com/CheckNoopMarshal.T2' doesn't have any exported fields, nor custom marshaling`)
+	json.MarshalIndent(T2{}, "", "  ") //@ diag(`struct type 'example.com/CheckNoopMarshal.T2' doesn't have any exported fields, nor custom marshaling`)
 	// pointer vs non-pointer makes no difference
 	json.Marshal(&T2{}) //@ diag(`struct type 'example.com/CheckNoopMarshal.T2' doesn't have any exported fields, nor custom marshaling`)
 	// exported field
@@ -94,7 +95,8 @@ func fn() {
 	json.Marshal(T23{})
 
 	// MarshalJSON does not apply to XML
-	xml.Marshal(T7{}) //@ diag(`struct type 'example.com/CheckNoopMarshal.T7' doesn't have any exported fields, nor custom marshaling`)
+	xml.Marshal(T7{})                 //@ diag(`struct type 'example.com/CheckNoopMarshal.T7' doesn't have any exported fields, nor custom marshaling`)
+	xml.MarshalIndent(T7{}, "", "  ") //@ diag(`struct type 'example.com/CheckNoopMarshal.T7' doesn't have any exported fields, nor custom marshaling`)
 	// MarshalXML
 	xml.Marshal(T8{})
 


### PR DESCRIPTION
While extracting a small test case from my real code for #1712, I suddenly could not longer reproduce it. Turns out that was because I used json.MarshalIndent() for my test case, and this function wasn't checked.

Fixes #1264