### PR TITLE
ST1021, ST1022: allow comments to start with deprecation comment

### DIFF
--- a/stylecheck/st1021/st1021.go
+++ b/stylecheck/st1021/st1021.go
@@ -84,6 +84,9 @@ func run(pass *analysis.Pass) (any, error) {
 					return false
 				}
 			}
+			if strings.HasPrefix(text, "Deprecated: ") {
+				return false
+			}
 
 			// Check comment before we strip articles in case the type's name is an article.
 			if strings.HasPrefix(text, node.Name.Name+" ") {

--- a/stylecheck/st1021/testdata/go1.0/CheckExportedTypeDocs/CheckExportedTypeDocs.go
+++ b/stylecheck/st1021/testdata/go1.0/CheckExportedTypeDocs/CheckExportedTypeDocs.go
@@ -58,3 +58,6 @@ type T14 struct{}
 
 // A does stuff.
 type A struct{}
+
+// Deprecated: don't use.
+type T15 struct{}

--- a/stylecheck/st1022/st1022.go
+++ b/stylecheck/st1022/st1022.go
@@ -74,6 +74,10 @@ func run(pass *analysis.Pass) (any, error) {
 			if !ok {
 				return false
 			}
+			if strings.HasPrefix(text, "Deprecated: ") {
+				return false
+			}
+
 			prefix := name + " "
 			if !strings.HasPrefix(text, prefix) {
 				kind := "var"

--- a/stylecheck/st1022/testdata/go1.0/CheckExportedVarDocs/CheckExportedVarDocs.go
+++ b/stylecheck/st1022/testdata/go1.0/CheckExportedVarDocs/CheckExportedVarDocs.go
@@ -39,3 +39,6 @@ var H int
 //some:directive //@ diag(`should be of the form`)
 // Whatever
 var I int
+
+// Deprecated: don't use.
+var J int


### PR DESCRIPTION
Add Support for variables and types, like functions in https://github.com/dominikh/go-tools/commit/38454214b6c7c9595637b12333de59ef919e9368 .