### PR TITLE
SA5008: add support for `embed` tag option

### DIFF
--- a/staticcheck/sa5008/jsonv2.go
+++ b/staticcheck/sa5008/jsonv2.go
@@ -141,7 +141,7 @@ func validateJSONTag(pass *analysis.Pass, field *ast.Field, tag string) {
 				report.Report(pass, field.Tag,
 					fmt.Sprintf("invalid appearance of unknown `case:%s` tag value", rawOpt))
 			}
-		case "inline":
+		case "embed", "inline":
 		case "unknown":
 		case "omitzero":
 		case "omitempty":


### PR DESCRIPTION
In golang/go#79985, it was decided to rename `inline` as `embed` to avoid compatibility issues with existing appearances of the `inline` tag option.

Add `embed` as a tag option understood by the tool.